### PR TITLE
Adding fulltext ID fields for fixing fulltext unit tests

### DIFF
--- a/library/Opus/Search/Result/Match.php
+++ b/library/Opus/Search/Result/Match.php
@@ -60,6 +60,16 @@ class Opus_Search_Result_Match {
 	protected $serverDateModified = null;
 
 	/**
+	 * @var
+	 */
+	protected $fulltextIdSuccess = null;
+
+	/**
+	 * @var
+	 */
+	protected $fulltextIdFailure = null;
+
+	/**
 	 * Caches current document's mapping of containing serieses into document's
 	 * number in either series.
 	 *
@@ -202,6 +212,42 @@ class Opus_Search_Result_Match {
 		}
 
 		return $this->getDocument()->getServerDateModified();
+	}
+
+	public function setFulltextIDsSuccess( $value ) {
+		if ( !is_null( $this->fulltextIdSuccess ) ) {
+			throw new RuntimeException( 'successful fulltext IDs have been set before' );
+		}
+
+		$this->fulltextIdSuccess = $value;
+
+		return $this;
+	}
+
+	public function getFulltextIDsSuccess() {
+		if ( !is_null( $this->fulltextIdSuccess ) ) {
+			return $this->fulltextIdSuccess;
+		}
+
+		return null;
+	}
+
+	public function setFulltextIDsFailure( $value ) {
+		if ( !is_null( $this->fulltextIdFailure ) ) {
+			throw new RuntimeException( 'failed fulltext IDs have been set before' );
+		}
+
+		$this->fulltextIdFailure = $value;
+
+		return $this;
+	}
+
+	public function getFulltextIDsFailure() {
+		if ( !is_null( $this->fulltextIdFailure ) ) {
+			return $this->fulltextIdFailure;
+		}
+
+		return null;
 	}
 
 	/**

--- a/library/Opus/Search/Solr/Solarium/Adapter.php
+++ b/library/Opus/Search/Solr/Solarium/Adapter.php
@@ -348,6 +348,14 @@ class Opus_Search_Solr_Solarium_Adapter extends Opus_Search_Adapter implements O
 							$match->setServerDateModified( $fieldValue );
 							break;
 
+						case 'fulltext_id_success' :
+							$match->setFulltextIDsSuccess( $fieldValue );
+							break;
+
+						case 'fulltext_id_failure' :
+							$match->setFulltextIDsFailure( $fieldValue );
+							break;
+
 						default :
 							$match->setAsset( $this->mapResultFieldToAsset( $fieldName ), $fieldValue );
 							break;


### PR DESCRIPTION
By adding these two fields to new result descriptor (Match) tests on assessing fulltext capabilities succeeded in my case.