### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
   - tar xfz solr-7.6.0.tgz
   - cd solr-7.6.0
   - ./bin/solr start
-  - ./bin/solr create -c solr
-  - cd server/solr/solr
+  - ./bin/solr create -c opus4
+  - cd server/solr/opus4
   - git clone https://github.com/OPUS4/opus4-search
   - cd conf
   - rm -f managed-schema schema.xml solrconfig.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+  - 7.0
+services:
+  - mysql
+before_script: composer install
+script: 
+  - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
+  - php db/createdb.php
+  - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
+  - phpunit --configuration ./tests/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ dist: xenial
 language: php
 php:
   - 7.0
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y openjdk-8-jdk
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 services:
   - mysql
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ dist: xenial
 language: php
 php:
   - 7.0
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+jdk:
+  - openjdk8
 services:
   - mysql
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: xenial
 language: php
 php:
   - 7.0
+jdk:
+  - oraclejdk8  
 services:
   - mysql
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - cd solr-5.5.5
   - ./bin/solr start
   - ./bin/solr create -c solr
+  - ls server/*
   - cd server/solr/solr
   - git clone https://github.com/OPUS4/opus4-search
   - cd conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ script:
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
-  - phpunit --configuration ./tests/phpunit.xml
+  - ./vendor/bin/phpunit --configuration ./tests/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
   - wget https://archive.apache.org/dist/lucene/solr/7.6.0/solr-7.6.0.tgz
-  - tar xfz solr-7.6.6.tgz
+  - tar xfz solr-7.6.0.tgz
   - cd solr-7.6.0
   - ./bin/solr start
   - ./bin/solr create -c opus4

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - rm -f managed-schema schema.xml solrconfig.xml
   - ln -s ../opus4-search/schema.xml
   - ln -s ../opus4-search/solrconfig.xml
-  - cd ../../../
+  - cd ../../../../
   - ./bin/solr restart  
   - cd ..
   - ./vendor/bin/phpunit --configuration ./tests/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
   - mysql
 before_script: composer install
 script: 
+  - mysql --version
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,9 @@ script:
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
+  - mkdir solr
+  - cd solr
+  - wget http://archive.apache.org/dist/lucene/solr/5.5.5/solr-5.5.5.tgz
+  - tar xfz solr-5.5.5.tgz
+  - solr-5.5.5/bin/solr start  
   - ./vendor/bin/phpunit --configuration ./tests/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: php
 php:
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 before_script: composer install
 script: 
   - mysql --version
+  - java -version
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: xenial
 language: php
 php:
   - 7.0
-jdk:
-  - openjdk8
 services:
   - mysql
 before_script: composer install
@@ -13,12 +11,11 @@ script:
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
-  - wget http://archive.apache.org/dist/lucene/solr/5.5.5/solr-5.5.5.tgz
-  - tar xfz solr-5.5.5.tgz
-  - cd solr-5.5.5
+  - wget https://archive.apache.org/dist/lucene/solr/7.6.0/solr-7.6.0.tgz
+  - tar xfz solr-7.6.0.tgz
+  - cd solr-7.6.0
   - ./bin/solr start
   - ./bin/solr create -c solr
-  - ls server/*
   - cd server/solr/solr
   - git clone https://github.com/OPUS4/opus4-search
   - cd conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,18 @@ script:
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
-  - wget https://archive.apache.org/dist/lucene/solr/7.6.0/solr-7.6.0.tgz
-  - tar xfz solr-7.6.0.tgz
-  - cd solr-7.6.0
+  - wget https://archive.apache.org/dist/lucene/solr/7.0.1/solr-7.0.1.tgz
+  - tar xfz solr-7.0.1.tgz
+  - cd solr-7.0.1
   - ./bin/solr start
   - ./bin/solr create -c opus4
   - cd server/solr/opus4
   - git clone https://github.com/OPUS4/opus4-search
+  - git checkout 4.7  
   - cd conf
   - rm -f managed-schema schema.xml solrconfig.xml
-  - ln -s ../opus4-search/schema.xml
-  - ln -s ../opus4-search/solrconfig.xml
+  - ln -s ../opus4-search/config/schema-5.xml schema.xml
+  - ln -s ../opus4-search/config/solrconfig-5.xml solrconfig.xml
   - cd ../../../../
   - ./bin/solr restart  
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ dist: xenial
 language: php
 php:
   - 7.0
-jdk:
-  - oraclejdk8  
+addons:
+  apt:
+    packages:
+      - oracle-java8-set-default
 services:
   - mysql
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ dist: xenial
 language: php
 php:
   - 7.0
-addons:
-  apt:
-    packages:
-      - oracle-java8-set-default
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y openjdk-8-jdk
 services:
   - mysql
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,18 @@ script:
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
-  - mkdir solr
-  - cd solr
   - wget http://archive.apache.org/dist/lucene/solr/5.5.5/solr-5.5.5.tgz
   - tar xfz solr-5.5.5.tgz
-  - solr-5.5.5/bin/solr start  
+  - cd solr-5.5.5
+  - ./bin/solr start
+  - ./bin/solr create -c solr
+  - cd server/solr/solr
+  - git clone https://github.com/OPUS4/opus4-search
+  - cd conf
+  - rm -f managed-schema schema.xml solrconfig.xml
+  - ln -s ../opus4-search/schema.xml
+  - ln -s ../opus4-search/solrconfig.xml
+  - cd ../../../
+  - ./bin/solr restart  
+  - cd ..
   - ./vendor/bin/phpunit --configuration ./tests/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,16 @@ script:
   - mkdir -p tests/workspace/cache tests/workspace/files tests/workspace/log tests/workspace/tmp
   - php db/createdb.php
   - mysql opusdb -u root --password='' -e 'SELECT * FROM schema_version'
-  - wget https://archive.apache.org/dist/lucene/solr/7.0.1/solr-7.0.1.tgz
-  - tar xfz solr-7.0.1.tgz
-  - cd solr-7.0.1
+  - wget https://archive.apache.org/dist/lucene/solr/7.6.0/solr-7.6.0.tgz
+  - tar xfz solr-7.6.6.tgz
+  - cd solr-7.6.0
   - ./bin/solr start
   - ./bin/solr create -c opus4
   - cd server/solr/opus4
   - git clone https://github.com/OPUS4/opus4-search
-  - git checkout 4.7  
-  - cd conf
+  - cd opus4-search
+  - git checkout 4.7
+  - cd ../conf
   - rm -f managed-schema schema.xml solrconfig.xml
   - ln -s ../opus4-search/config/schema-5.xml schema.xml
   - ln -s ../opus4-search/config/solrconfig-5.xml solrconfig.xml

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -112,12 +112,12 @@ searchengine.solr.default.query.onedoc.query = "*:*"
 searchengine.solr.default.query.onedoc.rows = 1
 
 ;SEARCH ENGINE SETTINGS (deprecated)
-searchengine.index.host = @searchengine.index.host@
-searchengine.index.port = @searchengine.index.port@
-searchengine.index.app = @searchengine.index.app@
-searchengine.extract.host = @searchengine.extract.host@
-searchengine.extract.port = @searchengine.extract.port@
-searchengine.extract.app = @searchengine.extract.app@
+searchengine.index.host = localhost
+searchengine.index.port = 8983
+searchengine.index.app = /solr
+searchengine.extract.host = localhost
+searchengine.extract.port = 8983
+searchengine.extract.app = /solr
 searchengine.solr.facets = author_facet,year,doctype,language,has_fulltext,belongs_to_bibliography,subject,project,institute
 searchengine.solr.xsltfile = APPLICATION_PATH "/tests/resources/solr.xslt"
 

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -76,18 +76,18 @@ searchengine.solr.default.adapterClass = Opus_Search_Solr_Solarium_Adapter
 
 searchengine.solr.default.service.default.endpoint.primary.host = localhost
 searchengine.solr.default.service.default.endpoint.primary.port = 8983
-searchengine.solr.default.service.default.endpoint.primary.path = /solr
+searchengine.solr.default.service.default.endpoint.primary.path = /solr/opus4
 searchengine.solr.default.service.default.endpoint.primary.timeout = 10
 searchengine.solr.default.service.default.xsltfile = APPLICATION_PATH "/tests/Opus/Search/Solr/solr.xslt"
 searchengine.solr.default.service.default.marker = default
 
-searchengine.solr.default.service.index.endpoint.primary.port = localhost
-searchengine.solr.default.service.index.endpoint.primary.path = 8983
+searchengine.solr.default.service.index.endpoint.primary.port = 8983
+searchengine.solr.default.service.index.endpoint.primary.path = /solr/opus4
 searchengine.solr.default.service.index.marker = index
 
 searchengine.solr.default.service.search.endpoint.primary.host = localhost
 searchengine.solr.default.service.search.endpoint.primary.port = 8983
-searchengine.solr.default.service.search.endpoint.primary.path = /solr
+searchengine.solr.default.service.search.endpoint.primary.path = /solr/opus4
 searchengine.solr.default.service.search.marker = search
 
 searchengine.solr.default.service.extract.marker = extract
@@ -114,10 +114,10 @@ searchengine.solr.default.query.onedoc.rows = 1
 ;SEARCH ENGINE SETTINGS (deprecated)
 searchengine.index.host = localhost
 searchengine.index.port = 8983
-searchengine.index.app = /solr
+searchengine.index.app = /solr/opus4
 searchengine.extract.host = localhost
 searchengine.extract.port = 8983
-searchengine.extract.app = /solr
+searchengine.extract.app = /solr/opus4
 searchengine.solr.facets = author_facet,year,doctype,language,has_fulltext,belongs_to_bibliography,subject,project,institute
 searchengine.solr.xsltfile = APPLICATION_PATH "/tests/resources/solr.xslt"
 

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -74,20 +74,20 @@ autoloaderNamespaces.opus = 'Opus_'
 ;SEARCH ENGINE SETTINGS
 searchengine.solr.default.adapterClass = Opus_Search_Solr_Solarium_Adapter
 
-searchengine.solr.default.service.default.endpoint.primary.host = @searchengine.default.host@
-searchengine.solr.default.service.default.endpoint.primary.port = @searchengine.default.port@
-searchengine.solr.default.service.default.endpoint.primary.path = @searchengine.default.path@
+searchengine.solr.default.service.default.endpoint.primary.host = localhost
+searchengine.solr.default.service.default.endpoint.primary.port = 8983
+searchengine.solr.default.service.default.endpoint.primary.path = /solr
 searchengine.solr.default.service.default.endpoint.primary.timeout = 10
 searchengine.solr.default.service.default.xsltfile = APPLICATION_PATH "/tests/Opus/Search/Solr/solr.xslt"
 searchengine.solr.default.service.default.marker = default
 
-searchengine.solr.default.service.index.endpoint.primary.port = @searchengine.default.port@
-searchengine.solr.default.service.index.endpoint.primary.path = @searchengine.default.path@
+searchengine.solr.default.service.index.endpoint.primary.port = localhost
+searchengine.solr.default.service.index.endpoint.primary.path = 8983
 searchengine.solr.default.service.index.marker = index
 
-searchengine.solr.default.service.search.endpoint.primary.host = @searchengine.default.host@
-searchengine.solr.default.service.search.endpoint.primary.port = @searchengine.default.port@
-searchengine.solr.default.service.search.endpoint.primary.path = @searchengine.default.path@
+searchengine.solr.default.service.search.endpoint.primary.host = localhost
+searchengine.solr.default.service.search.endpoint.primary.port = 8983
+searchengine.solr.default.service.search.endpoint.primary.path = /solr
 searchengine.solr.default.service.search.marker = search
 
 searchengine.solr.default.service.extract.marker = extract

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -41,17 +41,17 @@ theme = foobar
 ; db.params.host = localhost
 ; db.params.port = 3306
 ; TODO use regular OPUS user account for tests
-db.params.username = @db.admin.name@
-db.params.password = @db.admin.password@
-db.params.dbname = @db.name@
+db.params.username = root
+db.params.password = ''
+db.params.dbname = opusdb
 ; TODO resolve need to specify credentials twice (unless regular user is used above)
-opusdb.params.admin.name = @db.admin.name@
-opusdb.params.admin.password = @db.admin.password@
+opusdb.params.admin.name = root
+opusdb.params.admin.password = ''
 
 db.debug = 1
 
-opusdb.params.admin.name = @db.admin.name@
-opusdb.params.admin.password = @db.admin.password@
+opusdb.params.admin.name = root
+opusdb.params.admin.password = ''
 
 ;OPUS SETTINGS
 workspacePath = APPLICATION_PATH "/tests/workspace"

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -1,0 +1,148 @@
+; This file is part of OPUS. The software OPUS has been originally developed
+; at the University of Stuttgart with funding from the German Research Net,
+; the Federal Department of Higher Education and Research and the Ministry
+; of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+;
+; OPUS 4 is a complete rewrite of the original OPUS software and was developed
+; by the Stuttgart University Library, the Library Service Center
+; Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+; the Saarland University and State Library, the Saxon State Library -
+; Dresden State and University Library, the Bielefeld University Library and
+; the University Library of Hamburg University of Technology with funding from
+; the German Research Foundation and the European Regional Development Fund.
+;
+; LICENCE
+; OPUS is free software; you can redistribute it and/or modify it under the
+; terms of the GNU General Public License as published by the Free Software
+; Foundation; either version 2 of the Licence, or any later version.
+; OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+; details. You should have received a copy of the GNU General Public License
+; along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+;
+; @category    Tests
+; @author      Ralf Claussnitzer <ralf.claussnitzer@slub-dresden.de>
+; @author      Thoralf Klein <thoralf.klein@zib.de>
+; @author      Jens Schwidder <schwidder@zib.de>
+; @copyright   Copyright (c) 2008-2018, OPUS 4 development team
+; @license     http://www.gnu.org/licenses/gpl.html General Public License
+
+; Database adapter configuration using standard Zend_db option names.
+; Have a look on Zend_Db::factory() method for information about adapter creation.
+
+[production]
+; The 'theme' setting can be used to select a different theme.
+; Need theme for unit tests.
+theme = foobar
+
+;DB SETTINGS
+; db.params.host = localhost
+; db.params.port = 3306
+; TODO use regular OPUS user account for tests
+db.params.username = @db.admin.name@
+db.params.password = @db.admin.password@
+db.params.dbname = @db.name@
+; TODO resolve need to specify credentials twice (unless regular user is used above)
+opusdb.params.admin.name = @db.admin.name@
+opusdb.params.admin.password = @db.admin.password@
+
+db.debug = 1
+
+opusdb.params.admin.name = @db.admin.name@
+opusdb.params.admin.password = @db.admin.password@
+
+;OPUS SETTINGS
+workspacePath = APPLICATION_PATH "/tests/workspace"
+resources.locale.default = 'de'
+
+;PHP SETTINGS
+phpSettings.display_startup_errors = 1
+phpSettings.display_errors = 1
+; TODO verify the two settings below
+phpSettings.error_reporting = E_ALL | E_STRICT
+phpSettings.date.timezone = Europe/Berlin
+
+;ZEND_APPLICATION SETTINGS
+includePaths.library = APPLICATION_PATH "/library"
+bootstrap.path = APPLICATION_PATH "/library/Opus/Bootstrap/Base.php"
+bootstrap.class = "Opus_Bootstrap_Base"
+appnamespace = "Application"
+autoloaderNamespaces.opus = 'Opus_'
+
+;SEARCH ENGINE SETTINGS
+searchengine.solr.default.adapterClass = Opus_Search_Solr_Solarium_Adapter
+
+searchengine.solr.default.service.default.endpoint.primary.host = @searchengine.default.host@
+searchengine.solr.default.service.default.endpoint.primary.port = @searchengine.default.port@
+searchengine.solr.default.service.default.endpoint.primary.path = @searchengine.default.path@
+searchengine.solr.default.service.default.endpoint.primary.timeout = 10
+searchengine.solr.default.service.default.xsltfile = APPLICATION_PATH "/tests/Opus/Search/Solr/solr.xslt"
+searchengine.solr.default.service.default.marker = default
+
+searchengine.solr.default.service.index.endpoint.primary.port = @searchengine.default.port@
+searchengine.solr.default.service.index.endpoint.primary.path = @searchengine.default.path@
+searchengine.solr.default.service.index.marker = index
+
+searchengine.solr.default.service.search.endpoint.primary.host = @searchengine.default.host@
+searchengine.solr.default.service.search.endpoint.primary.port = @searchengine.default.port@
+searchengine.solr.default.service.search.endpoint.primary.path = @searchengine.default.path@
+searchengine.solr.default.service.search.marker = search
+
+searchengine.solr.default.service.extract.marker = extract
+
+; declare separate named service used by Opus_Search_ConfigTest accessing
+; different named services
+searchengine.solr.special.service.default.endpoint.primary.path = /solr-special/
+searchengine.solr.special.service.search.endpoint.primary.host = "127.0.0.2"
+searchengine.solr.special.service.search.marker = search2
+searchengine.solr.special.service.extract.marker = extract2
+
+; declare separate named service addressing unavailable host used by
+; Opus_Search_Solr_Solarium_AdapterIndexingTest
+searchengine.solr.disfunct.service.default.endpoint.primary.host = 1.2.3.4
+searchengine.solr.disfunct.service.default.endpoint.primary.port = 12345
+searchengine.solr.disfunct.service.default.endpoint.primary.path = /solr-disfunct/
+
+; declare queries in runtime configuration used by Opus_Search_QueryTest
+searchengine.solr.default.query.alldocs.query = "*:*"
+
+searchengine.solr.default.query.onedoc.query = "*:*"
+searchengine.solr.default.query.onedoc.rows = 1
+
+;SEARCH ENGINE SETTINGS (deprecated)
+searchengine.index.host = @searchengine.index.host@
+searchengine.index.port = @searchengine.index.port@
+searchengine.index.app = @searchengine.index.app@
+searchengine.extract.host = @searchengine.extract.host@
+searchengine.extract.port = @searchengine.extract.port@
+searchengine.extract.app = @searchengine.extract.app@
+searchengine.solr.facets = author_facet,year,doctype,language,has_fulltext,belongs_to_bibliography,subject,project,institute
+searchengine.solr.xsltfile = APPLICATION_PATH "/tests/resources/solr.xslt"
+
+;LOGGING RELATED SETTINGS
+; if set to true all xml that is generated while indexing is prepared for logging
+log.prepare.xml = false
+log.level = DEBUG
+
+;DUMMY MAIL SERVER; See "server/scripts/opus-smtp-dumpserver.php" for a dummy
+;mail server, which accepts all mail.
+; mail.opus.smtp = localhost
+; mail.opus.port = 25000
+
+; Used to verify that file has been parsed properly
+syntaxCheck = production
+
+[testing : production]
+sql.schema.path =
+
+; URN SETTINGS
+; If you do not want to set URNs automatically, set these values blank or
+; comment them out
+urn.nid = nbn
+urn.nss = de:kobv:test-opus
+urn.autoCreate = true
+
+; Used to verify that file has been parsed properly
+syntaxCheck = testing


### PR DESCRIPTION
* Travis CI Konfigurationsdatei `.travis.yml` erstellt
* den Test `testVerifyWithVerifiedDoiWithReverification` robuster gemacht (nutzt statt localhost nun example.org)

Was muss noch gemacht werden?
* dynamische Bereitstellung einer OPUS-Konfigurationsdatei `test/config.ini`
* könnte man z.B. mittels `sed` dynamisch im `script`-Block der `.travis.yml` aus der Template-Datei `test/config.ini.template` erzeugen
* außerdem sollte nicht bei jedem Build auf Travis das Solr-Installationsarchiv neu heruntergeladen werden (dafür gibt es wohl ein Caching Feature, siehe https://docs.travis-ci.com/user/caching/); ggf. auch für Composer verwenden?
* in `.travis.yml` wird zusätzlich mittels `git clone` eine Arbeitskopie des Repos https://github.com/OPUS4/opus4-search erzeugt (und auf den Branch `4.7` gewechselt) - das ist fest verdrahtet und sieht nicht so gut aus; ich habe aber noch keine Idee, wie man das "sauber" und robust macht
* BTW: warum sind in dem `4.7` Branch eigentlich jeweils zwei Solr-Konfigurationsdateien und zwei Schemadateien (in diesen ist die Solr/Lucene-Version ebenfalls fest verdrahtet: `7.0` - ich habe dennoch den Solr in Version `7.6` benutzt; auch das muss angeglichen werden, um böse Überraschungen zu vermeiden, die durch Inkompatibilitäten entstehen könnten)

Du siehst also, dass es prinzipiell funktioniert. Es ist aber noch ein bisschen Polieren erforderlich.