### PR TITLE
Framework changes to support enrichment types

### DIFF
--- a/db/schema/011-Enhanced-enrichments.sql
+++ b/db/schema/011-Enhanced-enrichments.sql
@@ -1,0 +1,14 @@
+START TRANSACTION;
+
+-- Add columns to table enrichmentkeys to support enrichment types
+
+ALTER TABLE `enrichmentkeys`
+  ADD COLUMN `type`    VARCHAR(255) NULL COMMENT 'Name of enrichment type.',
+  ADD COLUMN `options` VARCHAR(255) NULL COMMENT 'Options to allow configuration of enrichment type.';
+
+-- Update database version
+
+TRUNCATE TABLE `schema_version`;
+INSERT INTO `schema_version` (`version`) VALUES (11);
+
+COMMIT;

--- a/library/Opus/Enrichment.php
+++ b/library/Opus/Enrichment.php
@@ -88,4 +88,13 @@ class Opus_Enrichment extends Opus_Model_Dependent_Abstract
         $this->addField($value);
     }
 
+    public function getEnrichmentKey() {
+        $keyName = $this->getField('KeyName')->getValue();
+        if (is_null($keyName) || $keyName === '') {
+            return null;
+        }
+
+        return Opus_EnrichmentKey::fetchByName($keyName);
+    }
+
 }

--- a/library/Opus/Enrichment/AbstractType.php
+++ b/library/Opus/Enrichment/AbstractType.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_AbstractType implements Opus_Enrichment_TypeInterface
+{
+
+    public function getName()
+    {
+        return substr(get_class($this), strlen('Opus_Enrichment_'));
+    }
+
+    public function getDescription()
+    {
+        return 'admin_enrichmenttype_' . strtolower($this->getName()) . '_description';
+    }
+
+    public function getFormElementName()
+    {
+        return 'Text';
+    }
+
+    public function getFormElement($value = null)
+    {
+        // Standardverhalten Text-Element, das nicht leer sein darf
+
+        $form = new Admin_Form_Document_Enrichment();
+        $options = array('required' => true, 'size' => 60); // FIXME required wenn checkbox?
+        $element = $form->createElement($this->getFormElementName(), Admin_Form_Document_Enrichment::ELEMENT_VALUE, $options);
+
+        if (!is_null($value)) {
+            $element->setValue($value);
+        }
+
+        return $element;
+    }
+
+    /**
+     * Mappt JSON als String, das in der Datenbank gespeichert ist, oder
+     * alternativ ein Array auf die internen Felder des vorliegenden Enrichment-Typs
+     *
+     * @param $options entweder String oder Array
+     */
+    public function setOptions($options)
+    {
+        if (is_array($options)) {
+            $optionsArray = $options;
+        }
+        else {
+            if (is_null($options) || $options === '') {
+                return;
+            }
+
+            $optionsArray = json_decode($options);
+            if (is_null($optionsArray)) {
+                $log = Opus_Log::get();
+                $log->err('could not decode JSON string: ' . $options);
+                return;
+            }
+        }
+
+        foreach ($optionsArray as $key => $value) {
+            $setMethod = 'set' . ucfirst($key);
+            if (method_exists($this, $setMethod)) {
+                $this->$setMethod($value);
+            }
+            else {
+                $log = Opus_Log::get();
+                $log->err('method ' . $setMethod . ' does not exist on enrichment type ' . get_class($this));
+            }
+        }
+    }
+
+    /**
+     * Erzeugt aus allen registrierten Options ein gefülltes JSON-Objekt, das
+     * als String zurückgegeben wird.
+     *
+     * @return JSON
+     */
+    public function getOptions()
+    {
+        $options = null;
+        foreach ($this->getOptionProperties() as $optionProperty) {
+            $methodName = 'get' . lcfirst($optionProperty);
+            $attributeValue = $this->$methodName();
+            if ($attributeValue != null) {
+                if (is_null($options)) {
+                    $options = array();
+                }
+                $options[$optionProperty] = $attributeValue;
+            }
+        }
+
+        if (is_null($options)) {
+            return null;
+        }
+
+        $result = json_encode($options);
+        if ($result === false) {
+            // Fehler bei der Erzegung des JSON
+            return null;
+        }
+        return $result;
+    }
+
+    /**
+     * Ermittelt die Klassennamen aller im System verfügbaren EnrichmentTypes.
+     */
+    public static function getAllEnrichmentTypes($rawNames = false)
+    {
+        $files = array_diff(scandir(__DIR__), array('.', '..', 'AbstractType.php', 'TypeInterface.php'));
+        $result = array();
+
+        if ($files === false) {
+            return $result;
+        }
+
+        foreach ($files as $file) {
+            if (substr($file, strlen($file) - 4) == '.php') {
+                // found PHP file - try to instantiate
+                $className = 'Opus_Enrichment_' . substr($file, 0, strlen($file) - 4);
+                $interfaces = class_implements($className);
+                if (in_array('Opus_Enrichment_TypeInterface', $interfaces)) {
+                    $type = new $className();
+                    if (!$rawNames) {
+                        $typeName = $type->getName();
+                        $result[$typeName] = $typeName;
+                    }
+                    else {
+                        $result[] = $className;
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function getOptionsAsString()
+    {
+        return null;
+    }
+
+    public function setOptionsFromString($string)
+    {
+        return null;
+    }
+
+    public function getOptionProperties()
+    {
+        return array();
+    }
+
+}

--- a/library/Opus/Enrichment/BooleanType.php
+++ b/library/Opus/Enrichment/BooleanType.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_BooleanType extends Opus_Enrichment_AbstractType
+{
+
+    public function getFormElementName()
+    {
+        return 'Checkbox';
+    }
+
+    public function getFormElement($value = null)
+    {
+        $form = new Admin_Form_Document_Enrichment();
+        $options = array('required' => true); // FIXME überhaupt erforderlich?
+        $element = $form->createElement($this->getFormElementName(), Admin_Form_Document_Enrichment::ELEMENT_VALUE, $options);
+        $element->removeDecorator('Label'); // kein Label anzeigen
+
+        if (!is_null($value)) {
+            $element->setValue($value);
+        }
+
+        return $element;
+    }
+
+}

--- a/library/Opus/Enrichment/RegexType.php
+++ b/library/Opus/Enrichment/RegexType.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_RegexType extends Opus_Enrichment_AbstractType
+{
+    private $regex = null;
+
+    public function getRegex()
+    {
+        return $this->regex;
+    }
+
+    public function setRegex($regex)
+    {
+        $this->regex = $regex;
+    }
+
+    public function getFormElement($value = null)
+    {
+        $element = parent::getFormElement();
+
+        $validator = new Zend_Validate_Regex(array('pattern' => '/' . $this->regex . '/'));
+        $validator->setMessage('admin_validate_error_regex_pattern');
+        $element->addValidator($validator);
+
+        if (!is_null($value)) {
+            $element->setValue($value);
+        }
+
+        return $element;
+    }
+
+    public function getOptionsAsString()
+    {
+        return $this->regex;
+    }
+
+    public function setOptionsFromString($string)
+    {
+        if (is_null($string)) {
+            return; // nothing to check
+        }
+
+        // check if given option string is a valid regular expression
+
+        // turn off error reporting and save current value for later restore
+        $old_error = error_reporting(0);
+
+        // add '/' delimiters to string that will be validated as a regex
+        $stringToCheck = '/' . $string . '/';
+
+        if (preg_match($stringToCheck, null) === false) {
+            $error = error_get_last();
+            $log = Opus_Log::get();
+            $log->warn('given type option regex ' . $string . ' is not valid: ' . $error);
+        }
+        else {
+            $this->regex = $string;
+        }
+
+        // restore previous error reporting level
+        error_reporting($old_error);
+    }
+
+    public function getOptionProperties()
+    {
+        return array('regex');
+    }
+
+}

--- a/library/Opus/Enrichment/SelectType.php
+++ b/library/Opus/Enrichment/SelectType.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_SelectType extends Opus_Enrichment_AbstractType
+{
+
+    /**
+     * enthält die zur Auswahl stehenden Werte
+     *
+     * @var
+     */
+    private $values = null;
+
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    public function setValues($values)
+    {
+        $this->values = $values;
+    }
+
+    public function getFormElementName()
+    {
+        return 'Select';
+    }
+
+    public function getFormElement($value = null)
+    {
+        $form = new Admin_Form_Document_Enrichment();
+        $options = array('required' => true);
+        $element = $form->createElement($this->getFormElementName(), Admin_Form_Document_Enrichment::ELEMENT_VALUE, $options);
+
+        if (!is_null($this->values)) {
+            $element->setMultiOptions($this->values);
+            $validator = new Zend_Validate_InArray(array_keys($this->values));
+            $validator->setMessage('admin_validate_error_select_inarray');
+            $element->addValidator($validator);
+        }
+
+        // wenn es sich um ein Select-Element handelt, dann steht in $value
+        // der Index des ausgewählten Eintrags (Zählung beginnt bei 0)
+        // der ausgewählte Wert muss aus dem Index abgeleitet werden wenn
+        if (!is_null($value)) {
+            $value = array_search($value, $this->values);
+            $element->setValue($value);
+        }
+
+        return $element;
+    }
+
+    /**
+     * Liefert einen String, in dem die einzelnen Optionen zeilenweise stehen.
+     */
+    public function getOptionsAsString()
+    {
+        $result = null;
+        if (!is_null($this->values)) {
+            foreach ($this->values as $value) {
+                if (is_null($result)) {
+                    $result = "";
+                }
+                else {
+                    $result .= "\n";
+                }
+                $result .= $value;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Übersetzt die Optionen im übergebenen String auf das interne Array.
+     * Hierbei wird die Eingabe zeilenweise ausgewertet, d.h. ein Wert pro Zeile.
+     *
+     * @param $string Optionen aus der Eingabe
+     */
+    public function setOptionsFromString($string)
+    {
+        $separator = "\r\n";
+        $line = strtok($string, $separator);
+        while ($line !== false) {
+            if (trim($line) !== '') {
+                if ($this->values == null) {
+                    $this->values = array();
+                }
+                $this->values[] = $line;
+            }
+            $line = strtok($separator);
+        }
+    }
+
+    public function getOptionProperties()
+    {
+        return array('values');
+    }
+}

--- a/library/Opus/Enrichment/TextType.php
+++ b/library/Opus/Enrichment/TextType.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_TextType extends Opus_Enrichment_AbstractType
+{
+
+}

--- a/library/Opus/Enrichment/TextareaType.php
+++ b/library/Opus/Enrichment/TextareaType.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_TextareaType extends Opus_Enrichment_AbstractType
+{
+    public function getFormElementName()
+    {
+        return 'Textarea';
+    }
+
+}

--- a/library/Opus/Enrichment/TypeInterface.php
+++ b/library/Opus/Enrichment/TypeInterface.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+interface Opus_Enrichment_TypeInterface
+{
+
+    /**
+     * Name für Anzeige, z.B. Auswahl beim Anlegen eines neuen EnrichmentKeys
+     *
+     * @return mixed
+     */
+    public function getName();
+
+    /**
+     * Für Anzeige (Rückgabe eines Übersetzungsschlüssels), um den Typ und
+     * die Art der Konfiguration näher zu erläutern. Wenn keine Beschreibung
+     * gewünscht wird, so muss diese Methode null oder den Leerstring zurückliefern.
+     *
+     * @return mixed
+     *
+     */
+    public function getDescription();
+
+    /**
+     * Name des Formularelements, das das Rendering im Dokument-Metadatenformular
+     * festlegt (z.B. Checkbox, Textfeld, Selectfeld, Textarea, etc.). Sollte
+     * mit einem Grossbuchstaben beginnen.
+     *
+     * @return mixed
+     */
+    public function getFormElementName();
+
+    /**
+     * Erzeugt eine Formularelement (inkl. Validatoren) für die Eingabe des
+     * Enrichment-Werts.
+     *
+     * Die Prüfung des eingegebenen Wertes erfolgt nur innerhalb der Application,
+     * aber nicht auf Framework-Ebene. Somit kann nicht verhindert werden, dass
+     * über die Framework-API nicht valide Enrichment-Werte für einen Enrichment-
+     * Key in der Datenbank gespeichert werden.
+     *
+     * Ist der übergebene Wert nicht null, so wird der Wert auch gleich in das
+     * erzeugte Formularelement eingetragen.
+     *
+     * @param null $value anzuzeigender Wert des Enrichments
+     */
+    public function getFormElement($value = null);
+
+    /**
+     * Optionen, die für die Konfiguration des Enrichment Types relevant sind
+     *
+     * @return mixed
+     */
+    public function getOptions();
+
+    /**
+     * Übersetzt die vom Benutzer eingegebene textuelle Typkonfiguration auf die
+     * interne Felder
+     *
+     * @param $string
+     *
+     */
+    public function setOptionsFromString($string);
+
+    /**
+     * Erzeugt eine textuelle Repräsentation der Typkonfiguration, die dem Benutzer
+     * angezeigt werden kann.
+     *
+     * @param $string
+     *
+     * @return mixed
+     */
+    public function getOptionsAsString();
+
+
+    /**
+     * liefert die Namen der Properties, die für die Erzeugung des JSON relevant sind
+     *
+     * @return mixed
+     */
+    public function getOptionProperties();
+}

--- a/library/Opus/Version.php
+++ b/library/Opus/Version.php
@@ -50,7 +50,7 @@ class Opus_Version
     /**
      * Version of database schema.
      */
-    const SCHEMA_VERSION = '10';
+    const SCHEMA_VERSION = '11';
 
     /**
      * Compare the specified Opus Framework version string $version

--- a/tests/Opus/Enrichment/RegexTypeTest.php
+++ b/tests/Opus/Enrichment/RegexTypeTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Tests
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_RegexTypeTest extends TestCase
+{
+
+    public function testSetOptionsFromStringWithValidRegex()
+    {
+        $regex = "^.*$";
+
+        $regexType = new Opus_Enrichment_RegexType();
+        $regexType->setOptionsFromString($regex);
+
+        $json = $regexType->getOptions();
+        $this->assertEquals('{"regex":"' . $regex . '"}', $json);
+
+        $this->assertEquals($regex, $regexType->getRegex());
+
+        $this->assertEquals($regex, $regexType->getOptionsAsString());
+    }
+
+
+    public function testSetOptionsFromStringWithInvalidRegex()
+    {
+        // this regex is intentionally invalid
+        $regex = "[";
+
+        $regexType = new Opus_Enrichment_RegexType();
+        $regexType->setOptionsFromString($regex);
+
+        $this->assertNull($regexType->getOptions());
+
+        $this->assertNull($regexType->getRegex());
+
+        $this->assertNull($regexType->getOptionsAsString());
+    }
+
+    public function testSetOptionsFromStringWithNullArgument()
+    {
+        $regexType = new Opus_Enrichment_RegexType();
+        $regexType->setOptionsFromString(null);
+
+        $this->assertNull($regexType->getOptions());
+
+        $this->assertNull($regexType->getRegex());
+
+        $this->assertNull($regexType->getOptionsAsString());
+    }
+
+    public function testSetOptions()
+    {
+        $regexType = new Opus_Enrichment_RegexType();
+
+        $regexAsJson = '{"regex":"^foo.*$"}';
+
+        $regexType->setOptions($regexAsJson);
+
+        $this->assertEquals($regexAsJson, $regexType->getOptions());
+        $this->assertEquals("^foo.*$", $regexType->getOptionsAsString());
+    }
+
+    public function testGetOptions()
+    {
+        $regexType = new Opus_Enrichment_RegexType();
+
+        $json = $regexType->getOptions();
+        $this->assertNull($json);
+
+        $regexType->setRegex("^.*$");
+        $json = $regexType->getOptions();
+        $this->assertEquals('{"regex":"^.*$"}', $json);
+    }
+
+    public function testGetOptionProperties()
+    {
+        $regexType = new Opus_Enrichment_RegexType();
+        $props = $regexType->getOptionProperties();
+        $this->assertEquals(array('regex'), $props);
+    }
+
+    public function testGetFormElementName()
+    {
+        $regexType = new Opus_Enrichment_RegexType();
+        $this->assertEquals('Text', $regexType->getFormElementName());
+    }
+
+}

--- a/tests/Opus/Enrichment/SelectTypeTest.php
+++ b/tests/Opus/Enrichment/SelectTypeTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Tests
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_SelectTypeTest extends TestCase
+{
+
+    public function testSetOptionsFromStringWithUnixLinebreaks()
+    {
+        $selectType = new Opus_Enrichment_SelectType();
+
+        $selectType->setOptionsFromString("1\n2\n3");
+
+        $json = $selectType->getOptions();
+        $this->assertEquals('{"values":["1","2","3"]}', $json);
+
+        $values = $selectType->getValues();
+
+        $this->assertEquals(3, count($values));
+        $this->assertEquals("1", $values[0]);
+        $this->assertEquals("2", $values[1]);
+        $this->assertEquals("3", $values[2]);
+
+        $this->assertEquals("1\n2\n3", $selectType->getOptionsAsString());
+    }
+
+    public function testSetOptionFromStringsWithWindowsLinebreaks()
+    {
+        $selectType = new Opus_Enrichment_SelectType();
+
+        $selectType->setOptionsFromString("1\r\n2\r\n3");
+
+        $json = $selectType->getOptions();
+        $this->assertEquals('{"values":["1","2","3"]}', $json);
+
+        $values = $selectType->getValues();
+
+        $this->assertEquals(3, count($values));
+        $this->assertEquals("1", $values[0]);
+        $this->assertEquals("2", $values[1]);
+        $this->assertEquals("3", $values[2]);
+
+        $this->assertEquals("1\n2\n3", $selectType->getOptionsAsString());
+    }
+
+    public function testSetOptionsFromStringWitEmptyValue()
+    {
+        $selectType = new Opus_Enrichment_SelectType();
+
+        $selectType->setOptionsFromString("");
+
+        $this->assertNull($selectType->getOptions());
+        $this->assertNull($selectType->getValues());
+        $this->assertNull($selectType->getOptionsAsString());
+    }
+
+    public function testSetOptions()
+    {
+        $selectType = new Opus_Enrichment_SelectType();
+
+        $valuesAsJson = '{"values":["foo","bar","baz"]}';
+
+        $selectType->setOptions($valuesAsJson);
+
+        $this->assertEquals($valuesAsJson, $selectType->getOptions());
+        $this->assertEquals("foo\nbar\nbaz", $selectType->getOptionsAsString());
+    }
+
+
+    public function testGetOptions()
+    {
+        $selectType = new Opus_Enrichment_SelectType();
+
+        $this->assertNull($selectType->getOptions());
+
+        $selectType->setValues(array("1", "2", "3"));
+        $json = $selectType->getOptions();
+
+        $this->assertEquals('{"values":["1","2","3"]}', $json);
+    }
+
+    public function testGetOptionProperties()
+    {
+        $selectType = new Opus_Enrichment_SelectType();
+        $props = $selectType->getOptionProperties();
+        $this->assertEquals(array('values'), $props);
+    }
+
+    public function testGetFormElementName()
+    {
+        $selectType = new Opus_Enrichment_SelectType();
+        $this->assertEquals('Select', $selectType->getFormElementName());
+    }
+
+}

--- a/tests/Opus/Enrichment/TextTypeTest.php
+++ b/tests/Opus/Enrichment/TextTypeTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Tests
+ * @package     Opus_Enrichment
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2019, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Opus_Enrichment_TextTypeTest extends TestCase
+{
+
+    public function testSetOptionsFromString()
+    {
+        $textType = new Opus_Enrichment_TextType();
+        $textType->setOptionsFromString("foo");
+
+        $this->assertNull($textType->getOptions());
+        $this->assertNull($textType->getOptionsAsString());
+    }
+
+    public function testGetDescription()
+    {
+        $textType = new Opus_Enrichment_TextType();
+        $this->assertEquals('admin_enrichmenttype_texttype_description', $textType->getDescription());
+    }
+
+    public function testGetName()
+    {
+        $textType = new Opus_Enrichment_TextType();
+        $this->assertEquals('TextType', $textType->getName());
+    }
+
+    public function testGetAllEnrichmentTypesRaw()
+    {
+        $resultArr = Opus_Enrichment_TextType::getAllEnrichmentTypes(true);
+        $this->assertNotEmpty($resultArr);
+    }
+
+    public function testGetAllEnrichmentTypes()
+    {
+        $resultArr = Opus_Enrichment_TextType::getAllEnrichmentTypes();
+        $this->assertNotEmpty($resultArr);
+    }
+
+    public function testRobustnessOfSetOptions()
+    {
+        $textType = new Opus_Enrichment_TextType();
+
+        $textType->setOptions(null);
+
+        $textType->setOptions("");
+
+        $textType->setOptions("{foo}");
+
+        $textType->setOptions('{"foo":"bar"}');
+
+        $textType->setOptions(array("foo"));
+
+        $textType->setOptions(array("foo" => "bar"));
+    }
+
+}

--- a/tests/Opus/EnrichmentKeyTest.php
+++ b/tests/Opus/EnrichmentKeyTest.php
@@ -80,11 +80,15 @@ class Opus_EnrichmentKeyTest extends TestCase
     {
         $ek = new Opus_EnrichmentKey();
         $ek->setName('baz');
+        $ek->setType('type');
+        $ek->setOptions('options');
         $ek->store();
 
         $ek = new Opus_EnrichmentKey('baz');
         $this->assertNotNull($ek);
         $this->assertEquals('baz', $ek->getName());
+        $this->assertEquals('type', $ek->getType());
+        $this->assertEquals('options', $ek->getOptions());
         $this->assertEquals(3, count(Opus_EnrichmentKey::getAll()));
         $this->assertEquals(1, count(Opus_EnrichmentKey::getAllReferenced()));
     }
@@ -139,7 +143,12 @@ class Opus_EnrichmentKeyTest extends TestCase
     {
         foreach (array('foo', 'bar') as $name) {
             $ek = new Opus_EnrichmentKey($name);
+            $ek->setType('type');
+            $ek->setOptions('options');
+
             $this->assertEquals($name, $ek->getName());
+            $this->assertEquals('type', $ek->getType());
+            $this->assertEquals('options', $ek->getOptions());
         }
     }
 
@@ -195,24 +204,32 @@ class Opus_EnrichmentKeyTest extends TestCase
         $key = new Opus_EnrichmentKey();
 
         $key->setName('mykey');
+        $key->setType('mytype');
+        $key->setOptions('myoptions');
 
         $data = $key->toArray();
 
         $this->assertEquals([
-            'Name' => 'mykey'
+            'Name' => 'mykey',
+            'Type' => 'mytype',
+            'Options' => 'myoptions',
         ], $data);
     }
 
     public function testFromArray()
     {
         $key = Opus_EnrichmentKey::fromArray([
-            'Name' => 'mykey'
+            'Name' => 'mykey',
+            'Type' => 'mytype',
+            'Options' => 'myoptions'
         ]);
 
         $this->assertNotNull($key);
         $this->assertInstanceOf('Opus_EnrichmentKey', $key);
 
         $this->assertEquals('mykey', $key->getName());
+        $this->assertEquals('mytype', $key->getType());
+        $this->assertEquals('myoptions', $key->getOptions());
     }
 
     public function testUpdateFromArray()
@@ -220,9 +237,13 @@ class Opus_EnrichmentKeyTest extends TestCase
         $key = new Opus_EnrichmentKey();
 
         $key->updateFromArray([
-            'Name' => 'mykey'
+            'Name' => 'mykey',
+            'Type' => 'mytype',
+            'Options' => 'myoptions'
         ]);
 
         $this->assertEquals('mykey', $key->getName());
+        $this->assertEquals('mytype', $key->getType());
+        $this->assertEquals('myoptions', $key->getOptions());
     }
 }


### PR DESCRIPTION
In diesem PR sind alle Änderungen im Framework (inkl. Tests) enthalten, um zukünftig Enrichment Types in OPUS 4 zu unterstützen. Geplant ist die Unterstützung mit der Version 4.6.4.