### PR TITLE
OPUSVIER-3994

### DIFF
--- a/library/Opus/Document.php
+++ b/library/Opus/Document.php
@@ -1200,19 +1200,12 @@ class Opus_Document extends Opus_Model_AbstractDb
         if (is_null($this->oldServerState) && !$this->serverStateChanged) {
             // erste Änderung des Wertes von serverState
             $this->oldServerState = $this->getServerState();
-            $this->serverStateChanged = true;
         }
-        else {
-            // Wert wurde bereits durch einen vorhergehenden Methodenaufruf geändert
-            // um festzustellen, ob es eine Änderung gab, erfolgt der Vergleich des
-            // übergebenen Wert mit dem zuvor zwischengespeicherten Referenzwert
-            if ($serverState !== $this->oldServerState) {
-                $this->serverStateChanged = true;
-            }
-            else {
-                $this->serverStateChanged = false;
-            }
-        }
+
+        // Wert wurde bereits durch einen vorhergehenden Methodenaufruf geändert
+        // um festzustellen, ob es eine Änderung gab, erfolgt der Vergleich des
+        // übergebenen Wert mit dem zuvor zwischengespeicherten Referenzwert
+        $this->serverStateChanged = ($serverState !== $this->oldServerState);
 
         return parent::setServerState($serverState);
     }

--- a/library/Opus/Document.php
+++ b/library/Opus/Document.php
@@ -113,7 +113,6 @@
  * @method void setServerDateDeleted(Opus_Date $date)
  * @method Opus_Date getServerDateDeleted()
  *
- * @method void setServerState(string $state)
  * @method string getServerState()
  *
  * @method void setType(string $type)
@@ -233,8 +232,6 @@ class Opus_Document extends Opus_Model_AbstractDb
                 self::$defaultPlugins = [
                     'Opus_Document_Plugin_Index',
                     'Opus_Document_Plugin_XmlCache',
-                    'Opus_Document_Plugin_IdentifierUrn',
-                    'Opus_Document_Plugin_IdentifierDoi'
                 ];
             }
         }
@@ -1166,6 +1163,19 @@ class Opus_Document extends Opus_Model_AbstractDb
             $this->setServerState($value);
         }
         $this->_primaryTableRow->server_state = $value;
+    }
+
+    public function setServerState($serverState) {
+        // DOI- und URN-Plugin brauchen grundsätzlich nur aufgerufen werden, wenn es tatsächlich eine Änderung
+        // des Attributs serverState gab, z.B. beim Freischalten eines Dokuments
+        // wenn das Dokument bereits freigeschaltet wurde, dann dürfen die beiden Plugins nicht aufgerufen
+        // werden, damit beim Speichern keine automatische DOI/URN-Generierung erfolgt
+        if (!($this->getServerState() === 'published' && $serverState === 'published')) {
+            $this->registerPlugin('Opus_Document_Plugin_IdentifierDoi');
+            $this->registerPlugin('Opus_Document_Plugin_IdentifierUrn');
+        }
+
+        parent::setServerState($serverState);
     }
 
     /**

--- a/library/Opus/Document.php
+++ b/library/Opus/Document.php
@@ -1175,7 +1175,7 @@ class Opus_Document extends Opus_Model_AbstractDb
             $this->registerPlugin('Opus_Document_Plugin_IdentifierUrn');
         }
 
-        parent::setServerState($serverState);
+        return parent::setServerState($serverState);
     }
 
     /**

--- a/library/Opus/Document/Plugin/IdentifierDoi.php
+++ b/library/Opus/Document/Plugin/IdentifierDoi.php
@@ -35,7 +35,8 @@
  * Plugin for generating identifiers of type DOI.
  *
  */
-class Opus_Document_Plugin_IdentifierDoi extends Opus_Model_Plugin_Abstract {
+class Opus_Document_Plugin_IdentifierDoi extends Opus_Model_Plugin_Abstract implements \Opus\Model\Plugin\ServerStateChangeListener
+{
 
     // was muss hier alles ausgewertet werden:
     // automatische Generierung einer DOI für das vorliegende Dokument, wenn

--- a/library/Opus/Document/Plugin/IdentifierDoi.php
+++ b/library/Opus/Document/Plugin/IdentifierDoi.php
@@ -49,31 +49,41 @@ class Opus_Document_Plugin_IdentifierDoi extends Opus_Model_Plugin_Abstract {
     // laut Spezifikation: jedes OPUS-Dokument kann maximal eine zugeordnete DOI haben
     // diese DOI ist entweder lokal oder extern
     // im Rahmen der automatischen DOI-Registrierung werden nur lokale DOIs betrachtet
-    public function postStoreInternal(Opus_Model_AbstractDb $model) {
-
+    public function postStoreInternal(Opus_Model_AbstractDb $model)
+    {
         $log = Zend_Registry::get('Zend_Log');
 
         if (!($model instanceof Opus_Document)) {
-            $log->err('found unexpected model class ' . get_class($model));
+            $log->err(__CLASS__ . ' found unexpected model class ' . get_class($model));
             return;
         }
 
         $serverState = $model->getServerState();
         $log->debug(__CLASS__ . ' postStoreInternal for ' . $model->getDisplayName() . ' and target state ' . $serverState);
 
-        if ($serverState == 'published') {
-            $this->handlePublishEvent($model, $log);
+        if ($serverState !== 'published') {
+            $log->debug(__CLASS__ . ' postStoreInternal: nothing to do for document with server state ' . $serverState);
             return;
         }
 
-        if ($serverState == 'deleted') {
-            $this->handleDeleteEvent($model);
+        $this->handlePublishEvent($model, $log);
+    }
+
+    public function postDelete($modelId)
+    {
+        // check if database contains document with given id
+        $doc = null;
+        try {
+            $doc = new Opus_Document($modelId);
+        }
+        catch (Opus_Model_NotFoundException $e) {
+            // ignore silently and exit method since we do not need to perform any action
             return;
         }
 
-        $log->debug(__CLASS__ . ' postStoreInternal: nothing to do for documents with server state ' . $serverState);
-
-        return;
+        if ($doc != null && $doc->getServerState() === 'deleted') {
+            $this->handleDeleteEvent($doc);
+        }
     }
 
     private function handleDeleteEvent($document) {

--- a/library/Opus/Document/Plugin/IdentifierUrn.php
+++ b/library/Opus/Document/Plugin/IdentifierUrn.php
@@ -40,7 +40,7 @@
  * @package     Opus_Document_Plugin
  * @uses        Opus_Model_Plugin_Abstract
  */
-class Opus_Document_Plugin_IdentifierUrn extends Opus_Model_Plugin_Abstract 
+class Opus_Document_Plugin_IdentifierUrn extends Opus_Model_Plugin_Abstract implements \Opus\Model\Plugin\ServerStateChangeListener
 {
 
     /**

--- a/library/Opus/Document/Plugin/IdentifierUrn.php
+++ b/library/Opus/Document/Plugin/IdentifierUrn.php
@@ -49,17 +49,20 @@ class Opus_Document_Plugin_IdentifierUrn extends Opus_Model_Plugin_Abstract
      */
     public function postStoreInternal(Opus_Model_AbstractDb $model) 
     {
-        if(!($model instanceof Opus_Document))
-            return;
+        $log = Zend_Registry::get('Zend_Log');
 
-        if ($model->getServerState() !== 'published') {
+        if (!($model instanceof Opus_Document)) {
+            $log->err(__CLASS__ . ' found unexpected model class ' . get_class($model));
             return;
         }
 
-        $config = Zend_Registry::get('Zend_Config');
-        $log = Zend_Registry::get('Zend_Log');
+        $serverState = $model->getServerState();
+        $log->debug(__CLASS__ . ' postStoreInternal for ' . $model->getDisplayName() . ' and target state ' . $serverState);
 
-        $log->debug('IdentifierUrn postStoreInternal for ' . $model->getDisplayName());
+        if ($serverState !== 'published') {
+            $log->debug(__CLASS__ . ' postStoreInternal: nothing to do for document with server state ' . $serverState);
+            return;
+        }
 
         // prüfe zuerst, ob das Dokument das Enrichment opus.urn.autoCreate besitzt
         // in diesem Fall bestimmt der Wert des Enrichments, ob eine URN beim Publish generiert wird
@@ -71,6 +74,7 @@ class Opus_Document_Plugin_IdentifierUrn extends Opus_Model_Plugin_Abstract
             $log->debug('found enrichment opus.urn.autoCreate with value ' . $enrichmentValue);
         }
 
+        $config = Zend_Registry::get('Zend_Config');
         if (is_null($generateUrn)) {
             // Enrichment opus.urn.autoCreate wurde nicht gefunden - verwende Standardwert für die URN-Erzeugung aus Konfiguration
             $generateUrn = (isset($config->urn->autoCreate) && ($config->urn->autoCreate || $config->urn->autoCreate == '1'));

--- a/tests/Opus/Document/Plugin/IdentifierDoiTest.php
+++ b/tests/Opus/Document/Plugin/IdentifierDoiTest.php
@@ -350,14 +350,7 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $doc = new Opus_Document($docId);
         $this->assertEmpty($doc->getIdentifier());
 
-        $doiConfig = [
-            'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
-            'prefix' => '10.000/',
-            'localPrefix' => 'opustest',
-            'registerAtPublish' => 0,
-            'autoCreate' => 1
-        ];
-        $this->adaptDoiConfiguration($doiConfig);
+        $this->enableDOIGeneration();
 
         $doc = new Opus_Document($docId);
         // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
@@ -382,14 +375,7 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $doc = new Opus_Document($docId);
         $this->assertEmpty($doc->getIdentifier());
 
-        $doiConfig = [
-            'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
-            'prefix' => '10.000/',
-            'localPrefix' => 'opustest',
-            'registerAtPublish' => 0,
-            'autoCreate' => 1
-        ];
-        $this->adaptDoiConfiguration($doiConfig);
+        $this->enableDOIGeneration();
 
         $doc = new Opus_Document($docId);
         // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
@@ -415,14 +401,7 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $doc = new Opus_Document($docId);
         $this->assertEmpty($doc->getIdentifier());
 
-        $doiConfig = [
-            'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
-            'prefix' => '10.000/',
-            'localPrefix' => 'opustest',
-            'registerAtPublish' => 0,
-            'autoCreate' => 1
-        ];
-        $this->adaptDoiConfiguration($doiConfig);
+        $this->enableDOIGeneration();
 
         $doc = new Opus_Document($docId);
         // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
@@ -454,14 +433,7 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
      */
     public function testOPUSVIER3994publishedDocGetsDOI()
     {
-        $doiConfig = [
-            'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
-            'prefix' => '10.000/',
-            'localPrefix' => 'opustest',
-            'registerAtPublish' => 0,
-            'autoCreate' => 1
-        ];
-        $this->adaptDoiConfiguration($doiConfig);
+        $this->enableDOIGeneration();
 
         $doc = new Opus_Document();
         $doc->setServerState('unpublished');
@@ -475,5 +447,44 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $doi = $doc->getIdentifier()[0];
         $this->assertEquals('doi', $doi->getType());
         $this->assertEquals('10.000/opustest-' . $docId, $doi->getValue());
+    }
+
+    /**
+     * Keine DOI-Generierung, wenn effektiv keine Änderung des ServerState erfolgt
+     */
+    public function testOPUSVIER3994withoutServerStateChanged()
+    {
+        $doc = new Opus_Document();
+        $doc->setServerState('unpublished');
+        $docId = $doc->store();
+
+        $doc = new Opus_Document($docId);
+        $this->assertEmpty($doc->getIdentifier());
+
+        $this->enableDOIGeneration();
+
+        $doc = new Opus_Document($docId);
+        $doc->setServerState('published');
+        $doc->setServerState('unpublished');
+        $doc->store();
+
+        // prüfe, dass keine DOI generiert wurde (weil sich der ServerState nicht verändert hat)
+        $doc = new Opus_Document($docId);
+        $this->assertEmpty($doc->getIdentifier());
+    }
+
+    /**
+     * Hilfsmethode um die DOI-Generierung in der Konfiguration zu aktivieren.
+     */
+    private function enableDOIGeneration()
+    {
+        $doiConfig = [
+            'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
+            'prefix' => '10.000/',
+            'localPrefix' => 'opustest',
+            'registerAtPublish' => 0,
+            'autoCreate' => 1
+        ];
+        $this->adaptDoiConfiguration($doiConfig);
     }
 }

--- a/tests/Opus/Document/Plugin/IdentifierDoiTest.php
+++ b/tests/Opus/Document/Plugin/IdentifierDoiTest.php
@@ -360,9 +360,13 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $this->adaptDoiConfiguration($doiConfig);
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('1');
         // provoziere einen Statusübergang von published nach published
         $doc->setServerState('published');
         $doc->store();
+
+        $doc = new Opus_Document($docId);
         $this->assertEmpty($doc->getIdentifier());
     }
 
@@ -388,6 +392,8 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $this->adaptDoiConfiguration($doiConfig);
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('1');
         $doc->setServerState('published');
         $doc->store();
         $this->assertNotEmpty($doc->getIdentifier());
@@ -419,6 +425,8 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $this->adaptDoiConfiguration($doiConfig);
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('1');
         $doc->setServerState('published');
         $doc->setServerState('unpublished');
         $doc->store();
@@ -427,6 +435,8 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
         $this->assertEmpty($doc->getIdentifier());
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('2');
         $doc->setServerState('unpublished');
         $doc->setServerState('published');
         $doc->store();

--- a/tests/Opus/Document/Plugin/IdentifierDoiTest.php
+++ b/tests/Opus/Document/Plugin/IdentifierDoiTest.php
@@ -31,33 +31,39 @@
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 
-class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
+class Opus_Document_Plugin_IdentifierDoiTest extends TestCase
+{
 
     const ENRICHMENT_KEY_NAME = 'opus.doi.autoCreate';
 
-    private function setupEnrichmentKey() {
+    private function setupEnrichmentKey()
+    {
         $enrichmentKey = new Opus_EnrichmentKey();
         $enrichmentKey->setName(self::ENRICHMENT_KEY_NAME);
         $enrichmentKey->store();
     }
 
-    private function adaptDoiConfiguration($doiConfig) {
-        Zend_Registry::set('Zend_Config',
-            Zend_Registry::get('Zend_Config')->merge(new Zend_Config(array('doi' => $doiConfig))));
+    private function adaptDoiConfiguration($doiConfig)
+    {
+        Zend_Registry::set(
+            'Zend_Config',
+            Zend_Registry::get('Zend_Config')->merge(new Zend_Config(['doi' => $doiConfig]))
+        );
     }
 
-    private function createMinimalDocument($enrichmentValue = null) {
+    private function createMinimalDocument($enrichmentValue = null)
+    {
         $model = new Opus_Document();
         $model->setServerState('published');
 
-        if (!is_null($enrichmentValue)) {
+        if (! is_null($enrichmentValue)) {
             $this->setupEnrichmentKey();
 
             $enrichment = new Opus_Enrichment();
             $enrichment->setKeyName(self::ENRICHMENT_KEY_NAME);
             $enrichment->setValue($enrichmentValue);
 
-            $enrichments = array();
+            $enrichments = [];
             $enrichments[] = $enrichment;
             $model->setEnrichment($enrichments);
         }
@@ -69,14 +75,15 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
     /**
      * Überprüft, dass Konfigurationseinstellung doi.autoCreate korrekt angewendet wird.
      */
-    public function testDisabledAutoCreationOfDoiInConfig() {
-        $doiConfig = array(
+    public function testDisabledAutoCreationOfDoiInConfig()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'registerAtPublish' => 0,
             'autoCreate' => 0
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
         $docId = $this->createMinimalDocument();
 
@@ -86,14 +93,15 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
     /**
      * Überprüft, dass Konfigurationseinstellung doi.autoCreate korrekt angewendet wird.
      */
-    public function testDisabledAutoCreationOfDoiInConfigAlt() {
-        $doiConfig = array(
+    public function testDisabledAutoCreationOfDoiInConfigAlt()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'registerAtPublish' => 0,
             'autoCreate' => false
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
         $docId = $this->createMinimalDocument();
 
@@ -103,14 +111,15 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
     /**
      * Überprüft, dass Enrichment opus.doi.autoCreate die Konfigurationseinstellung überschreibt.
      */
-    public function testDisabledAutoCreationOfDoi() {
-        $doiConfig = array(
+    public function testDisabledAutoCreationOfDoi()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'registerAtPublish' => 0,
             'autoCreate' => 1
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
         $docId = $this->createMinimalDocument('false');
 
@@ -120,14 +129,15 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
     /**
      * Überprüft, dass Konfigurationseinstellung doi.autoCreate korrekt angewendet wird.
      */
-    public function testEnabledAutoCreationOfDoiInConfig() {
-        $doiConfig = array(
+    public function testEnabledAutoCreationOfDoiInConfig()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'registerAtPublish' => 0,
             'autoCreate' => 1
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
         $docId = $this->createMinimalDocument();
 
@@ -137,14 +147,15 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
     /**
      * Überprüft, dass Konfigurationseinstellung doi.autoCreate korrekt angewendet wird.
      */
-    public function testEnabledAutoCreationOfDoiInConfigAlt() {
-        $doiConfig = array(
+    public function testEnabledAutoCreationOfDoiInConfigAlt()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'registerAtPublish' => 0,
             'autoCreate' => true
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
         $docId = $this->createMinimalDocument();
 
@@ -154,21 +165,23 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
     /**
      * Überprüft, dass Enrichment opus.doi.autoCreate die Konfigurationseinstellung überschreibt.
      */
-    public function testEnabledAutoCreationOfDoi() {
-        $doiConfig = array(
+    public function testEnabledAutoCreationOfDoi()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'registerAtPublish' => 0,
             'autoCreate' => 0
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
         $docId = $this->createMinimalDocument('true');
 
         $this->assertGeneratedDoi($docId, 1);
     }
 
-    private function assertNoGeneratedDoi($docId, $numOfEnrichments = 0) {
+    private function assertNoGeneratedDoi($docId, $numOfEnrichments = 0)
+    {
         $model = new Opus_Document($docId);
         $this->assertEquals(0, count($model->getIdentifier()));
         $this->assertEquals(0, count($model->getIdentifierDoi()));
@@ -178,7 +191,8 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
         $this->assertEmpty($dois);
     }
 
-    private function assertGeneratedDoi($docId, $numOfEnrichments = 0) {
+    private function assertGeneratedDoi($docId, $numOfEnrichments = 0)
+    {
         $model = new Opus_Document($docId);
         $this->assertEquals(1, count($model->getIdentifier()));
         $this->assertEquals(1, count($model->getIdentifierDoi()));
@@ -192,14 +206,15 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
         $this->assertEquals('10.000/opustest-' . $docId, $doi->getValue());
     }
 
-    public function testSkipGenerationIfDoiAlreadyExists() {
-        $doiConfig = array(
+    public function testSkipGenerationIfDoiAlreadyExists()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'registerAtPublish' => 0,
             'autoCreate' => 1
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
 
         $doc = new Opus_Document();
@@ -208,7 +223,7 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
         $doi = new Opus_Identifier();
         $doi->setType('doi');
         $doi->setValue('1234');
-        $dois = array();
+        $dois = [];
         $dois[] = $doi;
         $doc->setIdentifier($dois);
 
@@ -235,14 +250,15 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
      * Der Status der lokalen DOI wird nicht verändert.
      *
      */
-    public function testHandleDeleteEvent() {
-        $doiConfig = array(
+    public function testHandleDeleteEvent()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'autoCreate' => 1,
             'doi.registration.datacite.serviceUrl' => 'localhost'
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
         $docId = $this->createMinimalDocument();
 
@@ -262,17 +278,18 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
         $this->assertCount(1, $dois);
         $doi = $dois[0];
         $this->assertEquals('doi', $doi->getType());
-        $this->assertEquals('10.000/opustest-' . $docId , $doi->getValue());
+        $this->assertEquals('10.000/opustest-' . $docId, $doi->getValue());
         $this->assertEquals('registered', $doi->getStatus());
     }
 
-    public function testDoiGenerationWithMissingGenerationClass() {
-        $doiConfig = array(
+    public function testDoiGenerationWithMissingGenerationClass()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_MissingGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'autoCreate' => 1,
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
 
         $docId = $this->createMinimalDocument();
@@ -282,15 +299,16 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
         $this->assertEmpty($identifiers);
     }
 
-    public function testDoiRegistration() {
-        $doiConfig = array(
+    public function testDoiRegistration()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'autoCreate' => 1,
             'registerAtPublish' => 1,
             'doi.registration.datacite.serviceUrl' => 'localhost'
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
 
         $docId = $this->createMinimalDocument();
@@ -305,15 +323,16 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
         $this->assertNull($doi->getStatus());
     }
 
-    public function testDoiRegistrationWithMissingLocalDoi() {
-        $doiConfig = array(
+    public function testDoiRegistrationWithMissingLocalDoi()
+    {
+        $doiConfig = [
             'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
             'prefix' => '10.000/',
             'localPrefix' => 'opustest',
             'autoCreate' => 0,
             'registerAtPublish' => 1,
             'doi.registration.datacite.serviceUrl' => 'localhost'
-        );
+        ];
         $this->adaptDoiConfiguration($doiConfig);
 
         $docId = $this->createMinimalDocument();
@@ -322,4 +341,59 @@ class Opus_Document_Plugin_IdentifierDoiTest extends TestCase {
         $this->assertEmpty($doc->getIdentifier());
     }
 
+    /**
+     * ein bereits veröffentlichtes Dokument ohne DOI soll beim erneuten Speichern keine DOI erhalten
+     */
+    public function testOPUSVIER3994wPublishedDoc()
+    {
+        $docId = $this->createMinimalDocument();
+        $doc = new Opus_Document($docId);
+        $this->assertEmpty($doc->getIdentifier());
+
+        $doiConfig = [
+            'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
+            'prefix' => '10.000/',
+            'localPrefix' => 'opustest',
+            'registerAtPublish' => 0,
+            'autoCreate' => 1
+        ];
+        $this->adaptDoiConfiguration($doiConfig);
+
+        $doc = new Opus_Document($docId);
+        // provoziere einen Statusübergang von published nach published
+        $doc->setServerState('published');
+        $doc->store();
+        $this->assertEmpty($doc->getIdentifier());
+    }
+
+    /**
+     * ein noch nicht veröffentlichtes Dokument ohne DOI soll beim erneuten Speichern eine DOI erhalten
+     */
+    public function testOPUSVIER3994wUnpublishedDoc()
+    {
+        $doc = new Opus_Document();
+        $doc->setServerState('unpublished');
+        $docId = $doc->store();
+
+        $doc = new Opus_Document($docId);
+        $this->assertEmpty($doc->getIdentifier());
+
+        $doiConfig = [
+            'generatorClass' => 'Opus_Doi_Generator_DefaultGenerator',
+            'prefix' => '10.000/',
+            'localPrefix' => 'opustest',
+            'registerAtPublish' => 0,
+            'autoCreate' => 1
+        ];
+        $this->adaptDoiConfiguration($doiConfig);
+
+        $doc = new Opus_Document($docId);
+        $doc->setServerState('published');
+        $doc->store();
+        $this->assertNotEmpty($doc->getIdentifier());
+
+        $doi = $doc->getIdentifier()[0];
+        $this->assertEquals('doi', $doi->getType());
+        $this->assertEquals('10.000/opustest-' . $docId, $doi->getValue());
+    }
 }

--- a/tests/Opus/Document/Plugin/IdentifierUrnTest.php
+++ b/tests/Opus/Document/Plugin/IdentifierUrnTest.php
@@ -34,9 +34,11 @@
  * @version     $Id$
  */
 
-class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
+class Opus_Document_Plugin_IdentifierUrnTest extends TestCase
+{
 
-    public function testAutoGenerateUrn() {
+    public function testAutoGenerateUrn()
+    {
         $model = new Opus_Document();
         $model->setServerState('published');
         $model->store();
@@ -50,8 +52,10 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
         $plugin = new Opus_Document_Plugin_IdentifierUrn();
         $plugin->postStoreInternal($model);
 
-        $this->assertTrue($model->hasField('Identifier'),
-                'Model does not have field "Identifier"');
+        $this->assertTrue(
+            $model->hasField('Identifier'),
+            'Model does not have field "Identifier"'
+        );
         $urns = $model->getIdentifier();
 
         $this->assertNotNull($urns, 'IdentifierUrn is NULL');
@@ -70,7 +74,8 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
      * Regression test for OPUSVIER-2252 - don't assign URN if not "published"
      * Check both fields: Identifier and IdentifierUrn.
      */
-    public function testAutoGenerateUrnSkippedIfNotPublished() {
+    public function testAutoGenerateUrnSkippedIfNotPublished()
+    {
         $model = new Opus_Document();
         $model->setServerState('unpublished');
         $model->store();
@@ -78,15 +83,19 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
         $model->addFile()->setVisibleInOai(0);
         $model->addFile()->setVisibleInOai(1);
 
-        $this->assertTrue($model->hasField('IdentifierUrn'),
-                'Model does not have field "IdentifierUrn"');
+        $this->assertTrue(
+            $model->hasField('IdentifierUrn'),
+            'Model does not have field "IdentifierUrn"'
+        );
         $urns = $model->getIdentifierUrn();
 
         $this->assertNotNull($urns, 'IdentifierUrn is NULL');
         $this->assertEquals(0, count($urns));
 
-        $this->assertTrue($model->hasField('Identifier'),
-                'Model does not have field "Identifier"');
+        $this->assertTrue(
+            $model->hasField('Identifier'),
+            'Model does not have field "Identifier"'
+        );
         $identifiers = $model->getIdentifier();
 
         $this->assertNotNull($identifiers, 'Identifier is NULL');
@@ -96,7 +105,8 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
     /**
      * Regression test for OPUSVIER-2445 - don't assign URN if no visible file
      */
-    public function testAutoGenerateUrnSkippedIfPublishedAndNoVisibleFiles() {
+    public function testAutoGenerateUrnSkippedIfPublishedAndNoVisibleFiles()
+    {
         $model = new Opus_Document();
         $model->setServerState('published');
         $model->addFile()->setVisibleInOai(0);
@@ -111,7 +121,8 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
     /**
      * Test urnAlreadyPresent in isolation
      */
-    public function testUrnAlreadyPresent() {
+    public function testUrnAlreadyPresent()
+    {
         $plugin = new Opus_Document_Plugin_IdentifierUrn();
 
         $model = new Opus_Document();
@@ -133,7 +144,8 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
     /**
      * Test allowUrnOnThisDocument in isolation
      */
-    public function testAllowUrnOnThisDocument() {
+    public function testAllowUrnOnThisDocument()
+    {
         $plugin = new Opus_Document_Plugin_IdentifierUrn();
 
         $model = new Opus_Document();
@@ -148,4 +160,77 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase {
         $this->assertTrue($plugin->allowUrnOnThisDocument($model));
     }
 
+    /**
+     * ein bereits veröffentlichtes Dokument ohne URN soll beim erneuten Speichern keine URN erhalten
+     */
+    public function testOPUSVIER3994wPublishedDoc()
+    {
+        $doc = new Opus_Document();
+        $doc->setServerState('published');
+        $docId = $doc->store();
+
+        $doc = new Opus_Document($docId);
+        $this->assertEmpty($doc->getIdentifier());
+
+        $visibleFile = new Opus_File();
+        $visibleFile->setPathName('visible_file.txt');
+        $visibleFile->setVisibleInOai(true);
+        $doc->addFile($visibleFile);
+        $doc->store();
+
+        $urnConfig = [
+            'autoCreate' => 1
+        ];
+        $this->adaptUrnConfiguration($urnConfig);
+
+        $doc = new Opus_Document($docId);
+        // provoziere einen Statusübergang von published nach published
+        $doc->setServerState('published');
+        $doc->store();
+        $this->assertEmpty($doc->getIdentifier());
+    }
+
+    /**
+     * ein noch nicht veröffentlichtes Dokument ohne URN soll beim erneuten Speichern eine URN erhalten
+     */
+    public function testOPUSVIER3994wUnpublishedDoc()
+    {
+        $doc = new Opus_Document();
+        $doc->setServerState('unpublished');
+
+        $visibleFile = new Opus_File();
+        $visibleFile->setPathName('visible_file.txt');
+        $visibleFile->setVisibleInOai(true);
+
+        $doc->addFile($visibleFile);
+        $docId = $doc->store();
+
+        $doc = new Opus_Document($docId);
+        $this->assertEmpty($doc->getIdentifier());
+
+        $urnConfig = [
+            'autoCreate' => 1,
+            'nss' => 'nss',
+            'nid' => 'nid'
+        ];
+        $this->adaptUrnConfiguration($urnConfig);
+
+        $doc = new Opus_Document($docId);
+        $doc->setServerState('published');
+        $doc->store();
+        $this->assertNotEmpty($doc->getIdentifier());
+
+        $urn = $doc->getIdentifier()[0];
+        $this->assertEquals('urn', $urn->getType());
+        $urnPrefix = 'urn:nid:nss-' . $docId;
+        $this->assertTrue(substr($urn->getValue(), 0, strlen($urnPrefix)) === $urnPrefix);
+    }
+
+    private function adaptUrnConfiguration($urnConfig)
+    {
+        Zend_Registry::set(
+            'Zend_Config',
+            Zend_Registry::get('Zend_Config')->merge(new Zend_Config(['urn' => $urnConfig]))
+        );
+    }
 }

--- a/tests/Opus/Document/Plugin/IdentifierUrnTest.php
+++ b/tests/Opus/Document/Plugin/IdentifierUrnTest.php
@@ -181,9 +181,13 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase
         $this->adaptUrnConfiguration($urnConfig);
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('1');
         // provoziere einen Statusübergang von published nach published
         $doc->setServerState('published');
         $doc->store();
+
+        $doc = new Opus_Document($docId);
         $this->assertEmpty($doc->getIdentifier());
     }
 
@@ -208,6 +212,8 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase
         $this->adaptUrnConfiguration($urnConfig);
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('1');
         $doc->setServerState('published');
         $doc->store();
         $this->assertNotEmpty($doc->getIdentifier());
@@ -239,6 +245,8 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase
         $this->adaptUrnConfiguration($urnConfig);
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('1');
         $doc->setServerState('published');
         $doc->setServerState('unpublished');
         $doc->store();
@@ -247,6 +255,8 @@ class Opus_Document_Plugin_IdentifierUrnTest extends TestCase
         $this->assertEmpty($doc->getIdentifier());
 
         $doc = new Opus_Document($docId);
+        // Änderung eines Wertes, damit store-Methode tatsächlich aufgerufen wird
+        $doc->setPageFirst('2');
         $doc->setServerState('unpublished');
         $doc->setServerState('published');
         $doc->store();

--- a/tests/Opus/DocumentTest.php
+++ b/tests/Opus/DocumentTest.php
@@ -2096,12 +2096,9 @@ class Opus_DocumentTest extends TestCase
         $doc = new Opus_Document();
         $this->assertTrue($doc->hasPlugin('Opus_Document_Plugin_Index'), 'Opus_Document_Plugin_Index is not registered');
         $this->assertTrue($doc->hasPlugin('Opus_Document_Plugin_XmlCache'), 'Opus_Document_Plugin_XmlCache is not registered');
+        $this->assertTrue($doc->hasPlugin('Opus_Document_Plugin_IdentifierUrn'), 'Opus_Document_Plugin_IdentifierUrn is registered');
+        $this->assertTrue($doc->hasPlugin('Opus_Document_Plugin_IdentifierDoi'), 'Opus_Document_Plugin_IdentifierDoi is registered');
         $this->assertFalse($doc->hasPlugin('Opus_Document_Plugin_SequenceNumber'), 'Opus_Document_Plugin_SequenceNumber is registered');
-
-        // die beiden nachfolgenden Plugins werden nur noch selektiv in Opus_Document beim Änderung von serverState
-        // registriert
-        $this->assertFalse($doc->hasPlugin('Opus_Document_Plugin_IdentifierUrn'), 'Opus_Document_Plugin_IdentifierUrn is registered');
-        $this->assertFalse($doc->hasPlugin('Opus_Document_Plugin_IdentifierDoi'), 'Opus_Document_Plugin_IdentifierDoi is registered');
     }
 
     /**
@@ -3909,7 +3906,9 @@ class Opus_DocumentTest extends TestCase
 
         $this->assertEquals([
             'Opus_Document_Plugin_Index',
-            'Opus_Document_Plugin_XmlCache'
+            'Opus_Document_Plugin_XmlCache',
+            'Opus_Document_Plugin_IdentifierUrn',
+            'Opus_Document_Plugin_IdentifierDoi'
         ], $document->getDefaultPlugins());
     }
 

--- a/tests/Opus/DocumentTest.php
+++ b/tests/Opus/DocumentTest.php
@@ -2096,8 +2096,12 @@ class Opus_DocumentTest extends TestCase
         $doc = new Opus_Document();
         $this->assertTrue($doc->hasPlugin('Opus_Document_Plugin_Index'), 'Opus_Document_Plugin_Index is not registered');
         $this->assertTrue($doc->hasPlugin('Opus_Document_Plugin_XmlCache'), 'Opus_Document_Plugin_XmlCache is not registered');
-        $this->assertTrue($doc->hasPlugin('Opus_Document_Plugin_IdentifierUrn'), 'Opus_Document_Plugin_IdentifierUrn is not registered');
         $this->assertFalse($doc->hasPlugin('Opus_Document_Plugin_SequenceNumber'), 'Opus_Document_Plugin_SequenceNumber is registered');
+
+        // die beiden nachfolgenden Plugins werden nur noch selektiv in Opus_Document beim Änderung von serverState
+        // registriert
+        $this->assertFalse($doc->hasPlugin('Opus_Document_Plugin_IdentifierUrn'), 'Opus_Document_Plugin_IdentifierUrn is registered');
+        $this->assertFalse($doc->hasPlugin('Opus_Document_Plugin_IdentifierDoi'), 'Opus_Document_Plugin_IdentifierDoi is registered');
     }
 
     /**
@@ -3905,9 +3909,7 @@ class Opus_DocumentTest extends TestCase
 
         $this->assertEquals([
             'Opus_Document_Plugin_Index',
-            'Opus_Document_Plugin_XmlCache',
-            'Opus_Document_Plugin_IdentifierUrn',
-            'Opus_Document_Plugin_IdentifierDoi',
+            'Opus_Document_Plugin_XmlCache'
         ], $document->getDefaultPlugins());
     }
 


### PR DESCRIPTION
Die Methode `setServerState` in `Opus_Document` wurde nun überschrieben, um dort selektiv die beiden Identifier-Plugins zu aktivieren. Standardmäßig sind die beiden Plugins nicht registriert. Das Vorgehen ist möglich, weil beide Plugins nur bei einer Änderung des Wertes von `serverState` anspringen sollen (daher muss `setServerState` zuvor aufgerufen worden sein). Das zu erwartende Verhalten wurde durch zwei Tests fixiert.