### PR TITLE
OPUSVIER-4052: Leere Sammlungen innerhalb des Browsings optional ausblenden

### DIFF
--- a/db/schema/012-Add-column-hide_empty_collections-to-collections_roles.sql
+++ b/db/schema/012-Add-column-hide_empty_collections-to-collections_roles.sql
@@ -1,0 +1,13 @@
+START TRANSACTION;
+
+-- add column hide_empty_collections to table collections_roles
+
+ALTER TABLE `collections_roles`
+  ADD COLUMN `hide_empty_collections` BOOLEAN NOT NULL DEFAULT 0 COMMENT 'Hide empty collections in collection browsing.';
+
+-- update database version
+
+TRUNCATE TABLE `schema_version`;
+INSERT INTO `schema_version` (`version`) VALUES (12);
+
+COMMIT;

--- a/library/Opus/Collection.php
+++ b/library/Opus/Collection.php
@@ -985,7 +985,7 @@ class Opus_Collection extends Opus_Model_AbstractDb
     }
 
     /**
-     * Returns documents of complete subtree.
+     * Returns number of published documents of complete subtree.
      *
      * @return int Number of subtree Entries.
      *

--- a/library/Opus/CollectionRole.php
+++ b/library/Opus/CollectionRole.php
@@ -92,6 +92,10 @@
  *
  * @method void setRootCollection(Opus_Collection $collection)
  * @method Opus_Collection getRootCollection()
+ *
+ * @method void setHideEmptyCollections(boolean $hideEmptyCollections)
+ * @method boolean getHideEmptyCollections()
+ * 
  */
 class Opus_CollectionRole extends Opus_Model_AbstractDb
 {
@@ -189,6 +193,11 @@ class Opus_CollectionRole extends Opus_Model_AbstractDb
         // Virtual attributes, which depend on other tables.
         $rootCollection = new Opus_Model_Field('RootCollection');
         $this->addField($rootCollection);
+
+        // Attribute to determine visibility of empty collections
+        $hideEmptyCollections = new Opus_Model_Field('HideEmptyCollections');
+        $hideEmptyCollections->setCheckbox(true);
+        $this->addField($hideEmptyCollections);
     }
 
     /**

--- a/library/Opus/Version.php
+++ b/library/Opus/Version.php
@@ -50,7 +50,7 @@ class Opus_Version
     /**
      * Version of database schema.
      */
-    const SCHEMA_VERSION = '11';
+    const SCHEMA_VERSION = '12';
 
     /**
      * Compare the specified Opus Framework version string $version

--- a/tests/Opus/CollectionRoleTest.php
+++ b/tests/Opus/CollectionRoleTest.php
@@ -186,6 +186,9 @@ class Opus_CollectionRoleTest extends TestCase
         );
     }
 
+    /**
+     * @param $role Opus_CollectionRole
+     */
     protected function prepateCollectionRole($role)
     {
         $role->setPosition(3);
@@ -198,6 +201,7 @@ class Opus_CollectionRoleTest extends TestCase
         $role->setIsClassification(0);
         $role->setAssignRoot(1);
         $role->setAssignLeavesOnly(0);
+        $role->setHideEmptyCollections(1);
     }
 
     /**
@@ -226,7 +230,8 @@ class Opus_CollectionRoleTest extends TestCase
             'IsClassification' => 0,
             'AssignRoot' => 1,
             'AssignLeavesOnly' => 0,
-            'RootCollection' => null
+            'RootCollection' => null,
+            'HideEmptyCollections' => 1
         ], $data);
     }
 
@@ -259,7 +264,8 @@ class Opus_CollectionRoleTest extends TestCase
             'IsClassification' => '0',
             'AssignRoot' => '1',
             'AssignLeavesOnly' => '0',
-            'RootCollection' => []
+            'RootCollection' => [],
+            'HideEmptyCollections' => 1
         ], $data);
     }
 
@@ -306,7 +312,8 @@ class Opus_CollectionRoleTest extends TestCase
             'RootCollection' => [
                 ['Id' => $col->getId(),'Name' => $col->getName()],
                 ['Id' => $col2->getId(),'Name' => $col2->getName()],
-            ]
+            ],
+            'HideEmptyCollections' => 1
         ], $data);
     }
 


### PR DESCRIPTION
Änderungen an Datenbank-Modell und Framework für die Umsetzung von OPUSVIER-4052