### PR TITLE
Marked Opus_SolrSearch_ResultList as deprecated

### DIFF
--- a/library/Opus/SolrSearch/ResultList.php
+++ b/library/Opus/SolrSearch/ResultList.php
@@ -29,7 +29,7 @@
  * @author      Sascha Szott <szott@zib.de>
  * @copyright   Copyright (c) 2008-2010, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
+ * @deprecated
  */
 
 class Opus_SolrSearch_ResultList {


### PR DESCRIPTION
Diese Klasse wurde noch an einer Stelle in der Application verwendet, und zwar beim XmlExport eines einzelnen Dokuments. Da dort aber keine Suche benötigt wird (Direktzugriff auf die Datenbank) ist die Verwendung der Klasse dort entfernt wurde (siehe PR https://github.com/OPUS4/application/pull/225), so dass die Klasse nun als *deprecated* markiert wird und nicht mehr verwendet werden sollte. Prinzipiell könnten wir die Klasse auch restlos entfernen, da es keine Nutzung mehr gibt.