### PR TITLE
OPUSVIER-4112

### DIFF
--- a/library/Opus/Db/Adapter/Pdo/Mysqlutf8.php
+++ b/library/Opus/Db/Adapter/Pdo/Mysqlutf8.php
@@ -65,7 +65,7 @@ class Opus_Db_Adapter_Pdo_Mysqlutf8 extends Zend_Db_Adapter_Pdo_Mysql
         }
 
         $config = Zend_Registry::get('Zend_Config');
-        if (isset($config, $config->db->debug) && $config->db->debug) {
+        if (isset($config, $config->db->debug) && filter_var($config->db->debug, FILTER_VALIDATE_BOOLEAN)) {
             $logger = Zend_Registry::get('Zend_Log');
             $logger->debug("Mysqlutf8: created new adapter");
 

--- a/library/Opus/Document/Plugin/IdentifierDoi.php
+++ b/library/Opus/Document/Plugin/IdentifierDoi.php
@@ -172,7 +172,7 @@ class Opus_Document_Plugin_IdentifierDoi extends Opus_Model_Plugin_Abstract impl
     {
 
         // prüfe ob Konfigurationseinstellung eine Registrierung vorgibt
-        if (! isset($config->doi->registerAtPublish) || ! ($config->doi->registerAtPublish || $config->doi->registerAtPublish == '1')) {
+        if (! isset($config->doi->registerAtPublish) || ! (filter_var($config->doi->registerAtPublish,FILTER_VALIDATE_BOOLEAN))) {
             $log->debug('registration of DOIs at publish time is disabled in configuration');
             return;
         }

--- a/library/Opus/Document/Plugin/IdentifierDoi.php
+++ b/library/Opus/Document/Plugin/IdentifierDoi.php
@@ -109,7 +109,7 @@ class Opus_Document_Plugin_IdentifierDoi extends Opus_Model_Plugin_Abstract impl
 
         if (is_null($generateDoi)) {
             // Enrichment opus.doi.autoCreate wurde nicht gefunden - verwende Standardwert für die DOI-Erzeugung aus Konfiguration
-            $generateDoi = (isset($config->doi->autoCreate) && ($config->doi->autoCreate || $config->doi->autoCreate == '1'));
+            $generateDoi = (isset($config->doi->autoCreate) && filter_var($config->doi->autoCreate, FILTER_VALIDATE_BOOLEAN));
         }
 
         // prüfe, ob bereits eine DOI mit dem Dokument verknüpft ist

--- a/library/Opus/Document/Plugin/IdentifierDoi.php
+++ b/library/Opus/Document/Plugin/IdentifierDoi.php
@@ -172,7 +172,7 @@ class Opus_Document_Plugin_IdentifierDoi extends Opus_Model_Plugin_Abstract impl
     {
 
         // prüfe ob Konfigurationseinstellung eine Registrierung vorgibt
-        if (! isset($config->doi->registerAtPublish) || ! (filter_var($config->doi->registerAtPublish,FILTER_VALIDATE_BOOLEAN))) {
+        if (! isset($config->doi->registerAtPublish) || ! (filter_var($config->doi->registerAtPublish, FILTER_VALIDATE_BOOLEAN))) {
             $log->debug('registration of DOIs at publish time is disabled in configuration');
             return;
         }

--- a/library/Opus/Document/Plugin/IdentifierUrn.php
+++ b/library/Opus/Document/Plugin/IdentifierUrn.php
@@ -77,7 +77,7 @@ class Opus_Document_Plugin_IdentifierUrn extends Opus_Model_Plugin_Abstract impl
         $config = Zend_Registry::get('Zend_Config');
         if (is_null($generateUrn)) {
             // Enrichment opus.urn.autoCreate wurde nicht gefunden - verwende Standardwert für die URN-Erzeugung aus Konfiguration
-            $generateUrn = (isset($config->urn->autoCreate) && ($config->urn->autoCreate || $config->urn->autoCreate == '1'));
+            $generateUrn = (isset($config->urn->autoCreate) && filter_var($config->urn->autoCreate, FILTER_VALIDATE_BOOLEAN));
         }
 
         if (! $generateUrn) {

--- a/library/Opus/Document/Plugin/Index.php
+++ b/library/Opus/Document/Plugin/Index.php
@@ -28,7 +28,6 @@
  * @author      Thoralf Klein <thoralf.klein@zib.de>
  * @copyright   Copyright (c) 2008-2010, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
  */
 
 /**
@@ -108,7 +107,7 @@ class Opus_Document_Plugin_Index extends Opus_Model_Plugin_Abstract
 
         $log = Opus_Log::get();
 
-        if (isset($this->config->runjobs->asynchronous) && $this->config->runjobs->asynchronous) {
+        if (isset($this->config->runjobs->asynchronous) && filter_var($this->config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)) {
             $log->debug(__METHOD__ . ': ' .'Adding remove-index job for document ' . $documentId . '.');
 
             $job = new Opus_Job();
@@ -149,7 +148,7 @@ class Opus_Document_Plugin_Index extends Opus_Model_Plugin_Abstract
         $log = Opus_Log::get();
 
         // create job if asynchronous is set
-        if (isset($this->config->runjobs->asynchronous) && $this->config->runjobs->asynchronous) {
+        if (isset($this->config->runjobs->asynchronous) && filter_var($this->config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)) {
             $log->debug(__METHOD__ . ': ' . 'Adding index job for document ' . $documentId . '.');
 
             $job = new Opus_Job();

--- a/library/Opus/Doi/DoiMailNotification.php
+++ b/library/Opus/Doi/DoiMailNotification.php
@@ -85,8 +85,8 @@ class Opus_Doi_DoiMailNotification
         if (is_null($this->enabled)) {
             // check if email notifications for DOI events are enabled in general
             if (isset($this->config->doi->notificationEmailEnabled)
-                && ($this->config->doi->notificationEmailEnabled || $this->config->doi->notificationEmailEnabled == '1')
-                && count($this->getRecipients()) > 0
+                && filter_var($this->config->doi->notificationEmailEnabled, FILTER_VALIDATE_BOOLEAN)
+                && (count($this->getRecipients()) > 0)
             ) {
                 $this->enabled = true;
             } else {

--- a/library/Opus/Search/Solr/Document/Xslt.php
+++ b/library/Opus/Search/Solr/Document/Xslt.php
@@ -82,7 +82,7 @@ class Opus_Search_Solr_Document_Xslt extends Opus_Search_Solr_Document_Base
         $solrDoc->preserveWhiteSpace = false;
         $solrDoc->loadXML($this->processor->transformToXML($modelXml));
 
-        if (Opus_Config::get()->log->prepare->xml) {
+        if (filter_var(Opus_Config::get()->log->prepare->xml, FILTER_VALIDATE_BOOLEAN)) {
             $modelXml->formatOutput = true;
             Opus_Log::get()->debug("input xml\n" . $modelXml->saveXML());
             $solrDoc->formatOutput = true;

--- a/library/Opus/Security/Realm.php
+++ b/library/Opus/Security/Realm.php
@@ -352,7 +352,7 @@ class Opus_Security_Realm implements Opus_Security_IRealm
     {
         // Check if security is switched off
         $conf = Zend_Registry::get('Zend_Config');
-        if (isset($conf) && (! filter_var($conf->security, FILTER_VALIDATE_BOOLEAN))) {
+        if (isset($conf, $conf->security) && (! filter_var($conf->security, FILTER_VALIDATE_BOOLEAN))) {
             return true;
         }
 

--- a/library/Opus/Security/Realm.php
+++ b/library/Opus/Security/Realm.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -33,7 +32,6 @@
  * @author      Ralf Claußnitzer (ralf.claussnitzer@slub-dresden.de)
  * @copyright   Copyright (c) 2008-2011, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
  */
 
 /**
@@ -354,7 +352,7 @@ class Opus_Security_Realm implements Opus_Security_IRealm
     {
         // Check if security is switched off
         $conf = Zend_Registry::get('Zend_Config');
-        if (isset($conf) and $conf->security === '0') {
+        if (isset($conf) && (! filter_var($conf->security, FILTER_VALIDATE_BOOLEAN))) {
             return true;
         }
 

--- a/library/Opus/Series.php
+++ b/library/Opus/Series.php
@@ -127,7 +127,7 @@ class Opus_Series extends Opus_Model_AbstractDb
     {
         $config = Zend_Registry::get('Zend_Config');
 
-        if (isset($config->series->sortByTitle) && $config->series->sortByTitle == '1') {
+        if (isset($config->series->sortByTitle) && filter_var($config->series->sortByTitle, FILTER_VALIDATE_BOOLEAN)) {
             $all = self::getAllFrom('Opus_Series', self::$_tableGatewayClass, null, 'title');
         } else {
             $all = self::getAllFrom('Opus_Series', self::$_tableGatewayClass);
@@ -145,7 +145,7 @@ class Opus_Series extends Opus_Model_AbstractDb
     {
         $config = Zend_Registry::get('Zend_Config');
 
-        if (isset($config->series->sortByTitle) && $config->series->sortByTitle == '1') {
+        if (isset($config->series->sortByTitle) && filter_var($config->series->sortByTitle, FILTER_VALIDATE_BOOLEAN)) {
             $all = self::getAll();
         } else {
             $all = self::getAllFrom(

--- a/library/Opus/SolrSearch/Index/Indexer.php
+++ b/library/Opus/SolrSearch/Index/Indexer.php
@@ -294,7 +294,7 @@ class Opus_SolrSearch_Index_Indexer
         $solrXmlDocument->preserveWhiteSpace = false;
         $solrXmlDocument->loadXML($proc->transformToXML($modelXml));
 
-        if (isset($config->log->prepare->xml) && $config->log->prepare->xml) {
+        if (isset($config->log->prepare->xml) && filter_var($config->log->prepare->xml, FILTER_VALIDATE_BOOLEAN)) {
             $modelXml->formatOutput = true;
             $this->log->debug("input xml\n" . $modelXml->saveXML());
             $solrXmlDocument->formatOutput = true;

--- a/tests/Opus/Document/Plugin/IndexTest.php
+++ b/tests/Opus/Document/Plugin/IndexTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -30,7 +29,6 @@
  * @author      Edouard Simon edouard.simon@zib.de
  * @copyright   Copyright (c) 2010-2012, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
  */
 class Opus_Document_Plugin_IndexTest extends TestCase
 {
@@ -39,12 +37,11 @@ class Opus_Document_Plugin_IndexTest extends TestCase
     {
         parent::setUp();
         $config = Zend_Registry::get('Zend_Config');
-        $config->merge(new Zend_Config(['runjobs' => ['asynchronous' => true]]));
+        $config->merge(new Zend_Config(['runjobs' => ['asynchronous' => '1']]));
     }
 
     public function testCreateIndexJob()
     {
-
         $indexJobsBefore = Opus_Job::getByLabels(['opus-index-document']);
         $jobCountBefore = count($indexJobsBefore);
 
@@ -71,8 +68,7 @@ class Opus_Document_Plugin_IndexTest extends TestCase
 
     public function testDoNotCreateIndexJobIfAsyncDisabled()
     {
-
-        Zend_Registry::get('Zend_Config')->runjobs->asynchronous = 0;
+        Zend_Registry::get('Zend_Config')->runjobs->asynchronous = ''; // false
 
         $indexJobsBefore = Opus_Job::getByLabels(['opus-index-document']);
         $jobCountBefore = count($indexJobsBefore);
@@ -91,7 +87,6 @@ class Opus_Document_Plugin_IndexTest extends TestCase
 
     public function testCreateRemoveIndexJob()
     {
-
         $removeIndexJobsBefore = Opus_Job::getByLabels(['opus-remove-index-document']);
         $jobCountBefore = count($removeIndexJobsBefore);
 
@@ -120,8 +115,7 @@ class Opus_Document_Plugin_IndexTest extends TestCase
 
     public function testDoNotCreateRemoveIndexJobIfAsyncDisabled()
     {
-
-        Zend_Registry::get('Zend_Config')->runjobs->asynchronous = 0;
+        Zend_Registry::get('Zend_Config')->runjobs->asynchronous = ''; // false
 
         $removeIndexJobsBefore = Opus_Job::getByLabels(['opus-remove-index-document']);
         $jobCountBefore = count($removeIndexJobsBefore);


### PR DESCRIPTION
Auch im Framework sollte der Zugriff auf boolesche Konfigurationswerte robuster gemacht werden, um mögliche Überraschungen zu vermeiden.