### PR TITLE
Nachtrag zu OPUSVIER-2103

### DIFF
--- a/library/Opus/EnrichmentKey.php
+++ b/library/Opus/EnrichmentKey.php
@@ -254,7 +254,7 @@ class Opus_EnrichmentKey extends Opus_Model_AbstractDb
     {
         $oldName = $this->getTableRow()->__get('name');
         $this->rename($this->getName(), $oldName);
-        parent::store();
+        return parent::store();
     }
 
     /**


### PR DESCRIPTION
Zum Glück haben wir Tests ;) Ich habe den gebrochenen Build in der Application analysiert und glatt festgestellt, dass ich ein `return` in der `store`-Funktion vergessen habe. Sobald dieser PR in den master gemergt wurde, sollte der Application Build wieder fehlerfrei durchlaufen.