### PR TITLE
Opusvier 3771 - Update for CI-System

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+# Update Ubuntu
+RUN apt-get update
+
+# Install system-packages
+RUN apt-get install -y debconf-utils\
+    composer\
+    wget\
+    unzip\
+    ant\
+    openjdk-8-jdk\
+    sudo
+
+# Install PHP
+RUN apt-get install -y php\
+    php-cli\
+    php-dev\
+    php-mbstring\
+    php-mysql\
+    php-curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:16.04
 
 # Update Ubuntu
 RUN apt-get update
+RUN apt-get update
 
 # Install system-packages
 RUN apt-get install -y debconf-utils\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,102 +1,88 @@
-#!groovy
-
-/**
-  * This Jenkinsfile is using to configurate an jenkins-job for testing at an CI-System
-  * For this a env-variable is used. This is for activate a short or an normal build.
-  * A short build do not check the coverage
-  * The short build will be activated, if the job_name has an 'night'-substring. This is actually hardcoded.
-  * So actually we made an different setup for night-containing jobs and for every other.
-  * Additionaly we have a 3 am trigger for night-builds(normal) and an 0 am trigger for every other.
-  * For MySQL we use a Docker.
-  * Pay Attention on the Port. In Line 49, the first port have to be set on the port in the config.ini
-  *
-  * TODO: Actually the normal build is also triggered with an push on github. We want, that short build are always
-  * triggerd with an push on github, but one time a day for minimum. Normal builds only triggered at night an 3 am.
-  */
-
 def jobNameParts = JOB_NAME.tokenize('/') as String[]
 def projectName = jobNameParts[0]
 
-node {
+if (projectName.contains('night')) {
+    TYPE = "long"
+} else {
+    TYPE = "short"
+}
 
-    if(projectName.contains('night')){
-        properties([
-            parameters([
-                string(name: 'Short_Build', defaultValue: 'FALSE')
-            ]),
-            pipelineTriggers([
-                cron('0 3 * * *')
-            ]),
-            disableConcurrentBuilds()
-        ])
-    }
-    else{
-        properties([
-            parameters([
-                string(name: 'Short_Build', defaultValue: 'TRUE')
-            ]),
-            pipelineTriggers([
-                cron('0 0 * * *')
-            ]),
-            disableConcurrentBuilds()
-        ])
+pipeline {
+    agent { dockerfile {args "-u root -v /var/run/docker.sock:/var/run/docker.sock"}}
+
+    triggers {
+        cron( TYPE.equals('long') ? 'H 3 * * *' : '')
     }
 
-    stage "checkout"
-    checkout scm
-
-    stage "prepare"
-    docker.image('mysql:5').withRun('-e "MYSQL_ROOT_PASSWORD=root" -p 3306:3306') { c ->
-        sh 'while ! mysqladmin ping -h0.0.0.0 --silent; do sleep 1; done'
-
-        stage "build"
-        sh 'ant setup prepare lint'
-
-        if ('${params.Short_Build}' == 'TRUE')
-        {
-            stage "Test"
-            sh 'ant phpunit'
-        }
-        else
-        {
-            stage "Test"
-            sh 'ant phpunit-fast'
+    stages {
+        stage('Composer') {
+            steps {
+                sh 'composer install'
+            }
         }
 
-        stage "analyse"
-        sh 'ant analyse-code'
+        stage('MySQL') {
+            steps {
+                sh 'sudo apt-get update'
+                sh 'sudo bash bin/install_mysql_docker.sh'
+            }
+        }
 
-        stage('Post-Script') {
+        stage('Prepare Opus4') {
+            steps {
+                sh 'ant prepare-workspace prepare-config lint -DdbUserPassword=root -DdbAdminPassword=root'
+                sh 'pecl install xdebug && echo "zend_extension=/usr/lib/php/20151012/xdebug.so" >> /etc/php/7.0/cli/php.ini'
+                sh 'sudo useradd opus4 && chown -R opus4:opus4 .'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                script{
+                  if (TYPE == 'short') {
+                     sh 'sudo -E -u opus4 ant phpunit-fast'
+                  } else if (TYPE == 'long') {
+                     sh 'sudo -E -u opus4 ant phpunit'
+                  }
+                }
+            }
+        }
+
+        stage('Analyse') {
+            steps {
+                script{
+                   if (TYPE == 'long') {
+                       sh 'ant analyse-code'
+                   }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
             step([
                 $class: 'JUnitResultArchiver',
                 testResults: 'build/logs/phpunit.xml'
             ])
-
+            step([
+                $class: 'CloverPublisher',
+                cloverReportDir: 'build/coverage',
+                cloverReportFileName: 'phpunit.coverage.xml"'
+            ])
             step([
                 $class: 'hudson.plugins.checkstyle.CheckStylePublisher',
                 pattern: 'build/logs/checkstyle.xml'
             ])
-
             step([
                 $class: 'hudson.plugins.dry.DryPublisher',
                 pattern: 'build/logs/pmd-cpd.xml'
             ])
-
             step([
                 $class: 'hudson.plugins.pmd.PmdPublisher',
                 pattern: 'build/logs/pmd.xml'
             ])
-
-            step([
-                $class: 'hudson.plugins.sloccount.SloccountPublisher',
-                pattern: 'build/logs/phploc.csv'
-            ])
-
-            step([
-                $class: 'CloverPublisher',
-                cloverReportDir: 'build',
-                cloverReportFileName: 'build/logs/phpunit.coverage.xml'
-            ])
+            step([$class: 'WsCleanup'])
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,8 @@ pipeline {
                 $class: 'hudson.plugins.pmd.PmdPublisher',
                 pattern: 'build/logs/pmd.xml'
             ])
-            step([$class: 'WsCleanup'])
+            sh "chmod -R 777 ."
+            step([$class: 'WsCleanup', externalDelete: 'rm -rf *'])
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         stage('Prepare Opus4') {
             steps {
                 sh 'ant prepare-workspace prepare-config lint -DdbUserPassword=root -DdbAdminPassword=root'
-                sh 'pecl install xdebug && echo "zend_extension=/usr/lib/php/20151012/xdebug.so" >> /etc/php/7.0/cli/php.ini'
+                // sh 'pecl install xdebug && echo "zend_extension=/usr/lib/php/20151012/xdebug.so" >> /etc/php/7.0/cli/php.ini'
                 sh 'sudo useradd opus4 && chown -R opus4:opus4 .'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         stage('Prepare Opus4') {
             steps {
                 sh 'ant prepare-workspace prepare-config lint -DdbUserPassword=root -DdbAdminPassword=root'
-                // sh 'pecl install xdebug && echo "zend_extension=/usr/lib/php/20151012/xdebug.so" >> /etc/php/7.0/cli/php.ini'
+                sh 'pecl install xdebug-2.8.0 && echo "zend_extension=/usr/lib/php/20151012/xdebug.so" >> /etc/php/7.0/cli/php.ini'
                 sh 'sudo useradd opus4 && chown -R opus4:opus4 .'
             }
         }

--- a/bin/install_mysql_docker.sh
+++ b/bin/install_mysql_docker.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Install MySQL with preconfig MySQL-password
+echo "mysql-server-5.5 mysql-server/root_password password root" | debconf-set-selections \
+    && echo "mysql-server-5.5 mysql-server/root_password_again password root" | debconf-set-selections \
+    && apt-get -y install mysql-server
+
+# Start MySQL
+sudo service mysql start
+
+# Create DB and user -> have to be in one line
+export MYSQL_PWD=root \
+    && mysql --default-character-set=utf8 -h 'localhost' -P '3306' -u 'root' -v -e "CREATE DATABASE IF NOT EXISTS opusdb DEFAULT CHARACTER SET = UTF8 DEFAULT COLLATE = UTF8_GENERAL_CI; GRANT ALL PRIVILEGES ON opusdb.* TO 'opus4'@'localhost' IDENTIFIED BY 'root'; GRANT SELECT,INSERT,UPDATE,DELETE ON opusdb.* TO 'opus4admin'@'localhost' IDENTIFIED BY 'root'; FLUSH PRIVILEGES;"

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
       "@test-coverage"
     ],
     "prepare": "mkdir -p build",
-    "test": "phpunit --colors=always",
+    "test": "phpunit --colors=always --log-junit build/phpunit.xml",
     "test-coverage": "phpunit --log-junit build/phpunit.xml --colors=always --coverage-html build/coverage/ --coverage-clover build/coverage/clover.xml",
     "cs-check": "phpcs -n",
     "cs-report": "phpcs -n --report=checkstyle --report-file=build/checkstyle.xml",


### PR DESCRIPTION
Hier ist das Update für Jenkins.

Anpassung im Composer.json, damit beim testen mit composer auch ein result angelegt wird.

Das Dockerfile liefert wieder die minimalistische Umgebung zum testen des Frameworks mit einigen wenigen Packages. Seit dem merge von 4.6.4 in 4.7 ist hier auch java notwendig. Ich habe das entsprechend nachgetragen.

Im Jenkinsfile wird, wie auch im common-paket, zwischen night und normal Build unterschieden.
Ein Night-Build wird immer gegen 03:00 gebaut. Hier wieder dynamisch, damit jenkins die ressourcen bestmöglich verteilen kann. Das Build läuft inklusive Analyse. Also coverage, cs, cpd, pmd und loc. 

Ein normaler Build hat keinen Trigger und macht nur einen fast-check ohne Analyse. Man kann ihn manuell starten oder richtet einen Webhook-Trigger ein. Von Jenkins aus, funktioniert das relative automatisch. Die Einstellungen müssen auf Github so erfolgen, dass bei einem push ein entsprechender Trigger gesendet wird. Als Beispiel für die Funktionsfähigkeit ist dieser Trigger im CI-System für meinen Fork des Common-Paketes eingerichtet. Wir können das dann hier für das Framework auch einrichten. Mehr Details dazu finden sich im Ticket.

Der MySQL-Server wird im Docker gebaut. Um das ein bisschen entkoppeln (besser zu warten) wird die Installation über ein seperates Script aufgerufen. Hier Install_mysql_docker.sh. Dort wird MySQL mit den grundlegensten DB-Einstellungen nach dem Vorbild unseres Installationsscripts aus der Applikation installiert. Dies stellt die DB zur Verfügung. 
Heißt Installation von mysql-server und dann erstellen der DB nach default-Config -> So wie sie auch in der build.xml für die Initialisierung der config.ini mittels ant stehen. 

Weitere Informationen finden sich im Ticket.