### PR TITLE
OPUSVIER-4202

### DIFF
--- a/library/Opus/Enrichment/RegexType.php
+++ b/library/Opus/Enrichment/RegexType.php
@@ -80,7 +80,6 @@ class RegexType extends AbstractType
         $element = parent::getFormElement();
 
         $validator = new \Zend_Validate_Regex(['pattern' => '/' . $this->regex . '/']);
-        $validator->setMessage('admin_validate_error_regex_pattern');
         $element->addValidator($validator);
 
         if (! is_null($value)) {

--- a/library/Opus/Enrichment/SelectType.php
+++ b/library/Opus/Enrichment/SelectType.php
@@ -92,7 +92,6 @@ class SelectType extends AbstractType
         if (! is_null($this->values)) {
             $element->setMultiOptions($this->values);
             $validator = new \Zend_Validate_InArray(array_keys($this->values));
-            $validator->setMessage('admin_validate_error_select_inarray');
             $element->addValidator($validator);
         }
 


### PR DESCRIPTION
Entfernung der Konfiguration von Übersetzungsschlüsseln (die in der Web-Applikation existieren) für Validierungsfehlern von EK-Typen