### PR TITLE
Opus\Person auf Doctrine umstellen

### DIFF
--- a/library/Opus/Db2/PersonRepository.php
+++ b/library/Opus/Db2/PersonRepository.php
@@ -31,7 +31,29 @@
 
 namespace Opus\Db2;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityRepository;
+use Opus\Date;
+use Opus\Document;
+use Opus\Model\ModelException;
+use Opus\Model2\Person;
+
+use function array_fill_keys;
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function array_push;
+use function array_search;
+use function array_unique;
+use function count;
+use function implode;
+use function in_array;
+use function is_array;
+use function lcfirst;
+use function property_exists;
+use function strlen;
+use function trim;
 
 /**
  * Database specific class for Person functions.
@@ -40,4 +62,532 @@ use Doctrine\ORM\EntityRepository;
  */
 class PersonRepository extends EntityRepository
 {
+    /**
+     * Constructs select statement for getting all persons matching criteria.
+     *
+     * @param  string|null $role
+     * @param  string|null $filter
+     * @return QueryBuilder
+     */
+    public function getAllPersonsSelect($role = null, $filter = null)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $columns = ['last_name', 'first_name', 'identifier_orcid', 'identifier_gnd', 'identifier_misc'];
+
+        $trimmedColumns = implode(
+            ',',
+            array_map(function ($value) {
+                return "trim($value) as $value";
+            }, $columns)
+        );
+
+        $groupColumns = implode(
+            ',',
+            array_map(function ($value) {
+                return "trim($value)";
+            }, $columns)
+        );
+
+        $identityColumns = implode(',', $columns);
+
+        $subSelect = $conn->createQueryBuilder()
+            ->select($trimmedColumns)
+            ->from('persons', 'pe');
+
+        if ($role !== null) {
+            $subSelect->join('pe', 'link_persons_documents', 'link', 'pe.id = link.person_id')
+                ->where('link.role = :role')
+                ->setParameter('role', $role);
+        }
+
+        if ($filter !== null) {
+            $subSelect->andWhere('last_name LIKE :lastName OR first_name LIKE :firstName')
+            ->setParameter('lastName', '%' . $filter . '%')
+            ->setParameter('firstName', '%' . $filter . '%');
+        }
+
+        // result still contains name duplicates because of leading spaces -> group trimmed result
+        $select = $conn->createQueryBuilder()
+            ->select($identityColumns)
+            ->from('(' . $subSelect->getSQL() . ') as p')
+            ->groupBy($groupColumns);
+
+        if ($subSelect->getParameters()) {
+            $select->setParameters($subSelect->getParameters());
+        }
+
+        return $select;
+    }
+
+    /**
+     * Returns all persons in the database without duplicates.
+     *
+     * Every real person might be represented by several objects, one for each document.
+     *
+     * @param string|null $role
+     * @param int         $start
+     * @param int         $limit
+     * @param string|null $filter
+     * @return array
+     */
+    public function getAllPersons($role = null, $start = 0, $limit = 0, $filter = null)
+    {
+        $select = $this->getAllPersonsSelect($role, $filter);
+
+        if ($start !== 0 || $limit !== 0) {
+            $select->setFirstResult($start)
+                ->setMaxResults($limit);
+        }
+
+        $select->orderBy('trim(last_name)')
+            ->addOrderBy('trim(first_name)');
+
+         return $select->execute()->fetchAllAssociative();
+    }
+
+    /**
+     * Returns total count of persons for role and filter string.
+     *
+     * @param string|null $role
+     * @param string|null $filter
+     * @return mixed
+     */
+    public function getAllPersonsCount($role = null, $filter = null)
+    {
+        $subSelect = $this->getAllPersonsSelect($role, $filter);
+
+        $conn   = $this->getEntityManager()->getConnection();
+        $select = $conn->createQueryBuilder()
+            ->select('count(*) as num')
+            ->from('(' . $subSelect->getSQL() . ') as pc');
+
+        if ($subSelect->getParameters()) {
+            $select->setParameters($subSelect->getParameters());
+        }
+
+        return $select->execute()->fetchOne();
+    }
+
+    /**
+     * Fetches all documents associated to the person by a certain role.
+     *
+     * @param Person $person The ID of the desired person.
+     * @param string $role The role that the person has for the documents.
+     * @return array An array of Opus\Document
+     */
+    public function getDocumentsByRole($person, $role)
+    {
+        if ($person->getId() === 0) {
+            return [];
+        }
+
+        $conn         = $this->getEntityManager()->getConnection();
+        $queryBuilder = $conn->createQueryBuilder();
+
+        $select = $queryBuilder->select('d.id')
+            ->from('documents', 'd')
+            ->join('d', 'link_persons_documents', 'link', 'd.id = link.document_id')
+            ->where('link.role = :role')
+            ->andWhere('link.person_id = :personId')
+            ->distinct()
+            ->setParameter('role', $role)
+            ->setParameter('personId', $person->getId());
+
+        $documents = [];
+
+        $result = $select->execute()->fetchFirstColumn();
+
+        foreach ($result as $id) {
+            $documents[] = Document::get($id);
+        }
+
+        return $documents;
+    }
+
+    /**
+     * Returns the ids for all linked documents.
+     *
+     * @param Person      $person
+     * @param string|null $role
+     * @return array
+     */
+    public function getDocumentIds($person, $role = null)
+    {
+        if ($person->getId() === 0) {
+            // TODO do more?
+            return [];
+        }
+
+        $conn         = $this->getEntityManager()->getConnection();
+        $queryBuilder = $conn->createQueryBuilder();
+
+        $select = $queryBuilder->select('distinct(document_id)')
+            ->from('link_persons_documents')
+            ->where('person_id = :personId')
+            ->setParameter('personId', $person->getId());
+
+        if ($role !== null) {
+            $select->andWhere('role = :role')
+                ->setParameter('role', $role);
+        }
+
+        return $select->execute()->fetchFirstColumn();
+    }
+
+    /**
+     * Get a list of IDs for Persons that have the specified role for
+     * certain documents.
+     *
+     * @param  string $role Role name.
+     * @return array List of Opus\Person Ids for Person models assigned to the specified Role.
+     */
+    public function getAllIdsByRole($role)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $select = $conn->createQueryBuilder()
+            ->select('person_id')
+            ->from('link_persons_documents')
+            ->where('role = :role')
+            ->setParameter('role', $role);
+
+        return $select->execute()->fetchFirstColumn();
+    }
+
+    /**
+     * Returns roles for a person.
+     *
+     * TODO verify columns
+     * TODO use object for person
+     *
+     * @param  array $person
+     * @return mixed
+     */
+    public function getPersonRoles($person)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $select = $conn->createQueryBuilder()
+            ->select('link.role, count(link.document_id) as documents')
+            ->from('link_persons_documents', 'link')
+            ->join('link', 'persons', 'p', 'link.person_id = p.id')
+            ->groupBy('link.role');
+
+        self::addWherePerson($select, $person);
+
+        return $select->execute()->fetchAllAssociative();
+    }
+
+    /**
+     * Returns document for person.
+     *
+     * The $person parameter is an array of columns and values that determine which person is meant.
+     *
+     * - first name
+     * - last name
+     * - identifier_orcid
+     * - identifier_gnd
+     * - identifier_misc
+     *
+     * @param array       $person
+     * @param string|null $state
+     * @param string|null $role
+     * @param string|null $sort
+     * @param bool        $order
+     * @return array
+     */
+    public function getPersonDocuments($person, $state = null, $role = null, $sort = null, $order = true)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $select = $conn->createQueryBuilder()
+            ->select('distinct(d.id)')
+            ->from('documents', 'd')
+            ->join('d', 'link_persons_documents', 'link', 'link.document_id = d.id')
+            ->join('link', 'persons', 'p', 'link.person_id = p.id');
+
+        self::addWherePerson($select, $person);
+
+        if (
+            $state !== null && in_array(
+                $state,
+                ['published', 'unpublished', 'inprogress', 'audited', 'restricted', 'deleted']
+            )
+        ) {
+            $select->andWhere('d.server_state = :state')->setParameter('state', $state);
+        }
+
+        if (
+            $role !== null && in_array(
+                $role,
+                ['author', 'editor', 'contributor', 'referee', 'advisor', 'other', 'translator', 'submitter']
+            )
+        ) {
+            $select->andWhere('link.role = :role')->setParameter('role', $role);
+        }
+
+        if ($sort !== null && in_array($sort, ['id', 'title', 'publicationDate', 'docType', 'author'])) {
+            switch ($sort) {
+                case 'id':
+                    $select->orderBy('d.id' . ($order ? ' ASC' : ' DESC'));
+                    break;
+                case 'title':
+                    $select->select('d.id, t.value');
+                    $select->join(
+                        'd',
+                        'document_title_abstracts',
+                        't',
+                        't.document_id = d.id'
+                    );
+                    $select->orderBy('t.value' . ($order ? ' ASC' : ' DESC'));
+                    break;
+                case 'publicationDate':
+                    $select->select('d.id, d.server_date_published');
+                    $select->orderBy('d.server_date_published' . ($order ? ' ASC' : ' DESC'));
+                    break;
+                case 'docType':
+                    $select->select('d.id, d.type');
+                    $select->orderBy('d.type' . ($order ? ' ASC' : ' DESC'));
+                    break;
+                case 'author':
+                    $select->select('d.id, p.last_name');
+                    $select->orderBy('p.last_name' . ($order ? ' ASC' : ' DESC'));
+                    break;
+            }
+        }
+
+        $documents = $select->execute()->fetchFirstColumn();
+
+        $documents = array_unique($documents); // just in case (TODO sorting by title creates duplicates)
+
+        return $documents;
+    }
+
+    /**
+     * Returns the value of matching person objects.
+     *
+     * @param array $person
+     * @return array|null
+     */
+    public function getPersonValues($person)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $result = null;
+
+        $select = $conn->createQueryBuilder()
+            ->select('*')
+            ->from('persons', 'p');
+
+        self::addWherePerson($select, $person);
+
+        $result = $select->execute();
+
+        if ($result->rowCount() === 0) {
+            return null;
+        }
+
+        $data = $result->fetchAllAssociative();
+
+        $merged = [];
+
+        foreach ($data as $personId => $values) {
+            foreach ($values as $key => $value) {
+                if (array_key_exists($key, $merged)) {
+                    $allValues = $merged[$key];
+
+                    if (is_array($allValues)) {
+                        if (array_search($value, $allValues) === false) {
+                            array_push($merged[$key], $value);
+                        }
+                    } else {
+                        if ($value !== $allValues) {
+                            $merged[$key] = [];
+                            array_push($merged[$key], $allValues, $value);
+                        }
+                    }
+                } else {
+                    $merged[$key] = $value;
+                }
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Returns ids of person objects matching criteria and documents.
+     *
+     * TODO filter by role?
+     *
+     * @param array      $person Criteria for matching persons
+     * @param array|null $documents Array with ids of documents
+     * @return array Array with IDs of persons
+     */
+    public function getPersons($person, $documents = null)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $select = $conn->createQueryBuilder()
+            ->select('distinct(p.id)')
+            ->from('persons', 'p');
+
+        // TODO handle single document id value
+        if ($documents !== null && is_array($documents) && count($documents) > 0) {
+            $select->join('p', 'link_persons_documents', 'link', 'link.person_id = p.id');
+            $select->where('link.document_id IN (:documents)')
+                ->setParameter('documents', $documents, Connection::PARAM_INT_ARRAY);
+        }
+
+        self::addWherePerson($select, $person);
+
+        return $select->execute()->fetchFirstColumn();
+    }
+
+    /**
+     * @param array      $person
+     * @param array|null $documents
+     * @return array
+     */
+    public function getPersonsAndDocuments($person, $documents = null)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $select = $conn->createQueryBuilder()
+            ->select('link.person_id', 'link.document_id')
+            ->from('persons', 'p')
+            ->join('p', 'link_persons_documents', 'link', 'link.person_id = p.id');
+
+        if ($documents !== null) {
+            $select->where('link.document_id IN (:documents)')
+                ->setParameter('documents', $documents, Connection::PARAM_INT_ARRAY);
+        }
+
+        self::addWherePerson($select, $person);
+
+        return $select->execute()->fetchAllAssociative();
+    }
+
+    /**
+     * @param array      $personIds
+     * @param array|null $documents
+     * @return array
+     */
+    public function getDocuments($personIds, $documents = null)
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $select = $conn->createQueryBuilder()
+            ->select('distinct(link.document_id)')
+            ->from('persons', 'p')
+            ->join('p', 'link_persons_documents', 'link', 'link.person_id = p.id')
+            ->where('link.person_id IN (:personIds)')
+            ->setParameter('personIds', $personIds, Connection::PARAM_INT_ARRAY);
+
+        if ($documents !== null && count($documents) > 0) {
+            $select->andWhere('link.document_id IN (:documents)')
+            ->setParameter('documents', $documents, Connection::PARAM_INT_ARRAY);
+        }
+
+        return $select->execute()->fetchFirstColumn();
+    }
+
+    /**
+     * @param QueryBuilder $select
+     * @param array        $person
+     *
+     * TODO review
+     *
+     * This currently adds criteria to match any person with matching values for the specified columns.
+     *
+     * TODO shoudln't it be an exact match for columns that are empty (only null/empty matches)?
+     *
+     * NOTE: Function updateAll does not use this, because there does not seem to be a way to hand over
+     * an update object like for the select.
+     */
+    protected static function addWherePerson($select, $person)
+    {
+        $defaults = array_fill_keys([
+            'last_name',
+            'first_name',
+            'identifier_orcid',
+            'identifier_gnd',
+            'identifier_misc',
+        ], null);
+        $person   = array_merge($defaults, $person);
+
+        foreach ($person as $column => $value) {
+            if (strlen(trim($value)) > 0) {
+                $select->andWhere("trim(p.$column) = :$column")
+                    ->setParameter($column, trim($value));
+            } else {
+                $select->andWhere("p.$column IS NULL");
+            }
+        }
+    }
+
+    /**
+     * Updates select columns of matching persons.
+     *
+     * Optionally the scope can be limited to specified set of documents.
+     *
+     * @param array      $person Criteria for matching persons
+     * @param array      $changes Map of column names and new values
+     * @param array|null $documents Array with document Ids
+     *
+     * TODO update ServerDateModified for modified documents (How?)
+     */
+    public function updateAll($person, $changes, $documents = null)
+    {
+        if (empty($person)) {
+            // TODO do logging?
+            return;
+        }
+
+        if (empty($changes)) {
+            // TODO do logging?
+            return;
+        }
+
+        foreach ($changes as $name => $value) {
+            if (! property_exists(Person::class, lcfirst($name))) {
+                // TODO use
+                throw new ModelException("unknown field '$name' for update");
+            } else {
+                if ($value !== null) {
+                    $changes[$name] = trim($value);
+                } else {
+                    $changes[$name] = null;
+                }
+            }
+        }
+
+        $personIds   = self::getPersons($person, $documents);
+        $documentIds = self::getDocuments($personIds, $documents);
+
+        if (! empty($personIds)) {
+            $queryBuilder = $this->getEntityManager()->createQueryBuilder();
+            $update       = $queryBuilder->update(Person::class, 'p');
+
+            foreach ($changes as $key => $value) {
+                $update->set('p.' . lcfirst($key), ':' . $key)
+                    ->setParameter($key, $value);
+            }
+
+            $update->where('p.id IN (:personIds)')
+                ->setParameter('personIds', $personIds, Connection::PARAM_INT_ARRAY);
+
+            $update->getQuery()->execute();
+
+            $this->getEntityManager()->clear(Person::class);
+
+            if (! empty($documentIds)) {
+                $date = new Date();
+                $date->setNow();
+
+                Document::setServerDateModifiedByIds($date, $documentIds);
+            }
+        }
+    }
 }

--- a/library/Opus/Db2/PersonRepository.php
+++ b/library/Opus/Db2/PersonRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2021, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+namespace Opus\Db2;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Database specific class for Person functions.
+ *
+ * This class keeps the database (Doctrine) specific code out of the model class.
+ */
+class PersonRepository extends EntityRepository
+{
+}

--- a/library/Opus/Model2/AbstractModel.php
+++ b/library/Opus/Model2/AbstractModel.php
@@ -41,6 +41,10 @@ use Opus\Model\DbException;
 use Opus\Model\NotFoundException;
 
 use function in_array;
+use function preg_replace;
+use function preg_replace_callback;
+use function strtolower;
+use function strtoupper;
 
 /**
  * Base class for OPUS 4 model classes.
@@ -60,6 +64,14 @@ abstract class AbstractModel
 
     // TODO The use of String as the type of $modelId become necessary due to the existence of models
     //      which do not use "id" as the primary key
+
+    /**
+     * @return static
+     */
+    public static function new()
+    {
+        return new static();
+    }
 
     /**
      * @param int|string $modelId
@@ -221,5 +233,29 @@ abstract class AbstractModel
         $model = new static();
         $model->updateFromArray($data);
         return $model;
+    }
+
+    /**
+     * @param string $fieldname Field name in camel case
+     * @return string Column name with case-change replaced by underscores "_"
+     */
+    public static function convertFieldnameToColumn($fieldname)
+    {
+        return strtolower(preg_replace('/(?!^)[[:upper:]]/', '_\0', $fieldname));
+    }
+
+    /**
+     * @param string $column Column name as string
+     * @return string Field name in camel case
+     */
+    public static function convertColumnToFieldname($column)
+    {
+        return preg_replace_callback(
+            '/(?:^|_)([a-z])([a-z]+)/',
+            function ($matches) {
+                return strtoupper($matches[1]) . $matches[2];
+            },
+            $column
+        );
     }
 }

--- a/library/Opus/Model2/Person.php
+++ b/library/Opus/Model2/Person.php
@@ -1,0 +1,410 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ *
+ * @category    Framework
+ * @package     Opus
+ */
+
+namespace Opus\Model2;
+
+use Doctrine\ORM\Mapping as ORM;
+
+use Opus\Date;
+use Opus\Db\LinkPersonsDocuments;
+use Opus\Db\TableGateway;
+use Opus\Model\AbstractDb;
+use Opus\Model\Field;
+use Opus\Model\ModelException;
+use Zend_Validate_EmailAddress;
+use Zend_Validate_NotEmpty;
+
+use function array_fill_keys;
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function array_push;
+use function array_search;
+use function array_unique;
+use function count;
+use function in_array;
+use function is_array;
+use function is_string;
+use function stristr;
+use function strlen;
+use function trim;
+
+/**
+ * Domain model for persons in the Opus framework
+ *
+ * The class includes a number of static methods for querying or updating the database. These functions are used for
+ * the management of persons in OPUS 4. They will be expanded and maybe moved later as the development of the
+ * management functions continues. Some of them might be replaced by code that uses the search index.
+ *
+ * At this point a real "person" is represented by all the objects matching the identification of that person. For
+ * the identification the following fields are used.
+ *
+ * - LastName
+ * - FirstName
+ * - IdentifierOrcid
+ * - IdentifierGnd
+ * - IdentifierMisc
+ *
+ * TODO Currently a mix of field and column names is used. That should be fixed.
+ *
+ * So a person is specified by providing values for the five identity fields. If not all values are specified, null is
+ * assumed and used for matching.
+ *
+ * A person object with the same name, but no identifier is not the same person as an object that does have an
+ * identifier. So if for a person only a last name is specified, persons with a first name or any kind of id are not
+ * considered the same person.
+ *
+ * TODO in next steps of development LastName and FirstName will become irrelevant and only identifier will be used
+ *
+ * There are currently no mechanisms to handle different writing of the name of a person or aliases.
+ *
+ * Two people with the same name can be distinguished by using an identifier.
+ *
+ * TODO use OPUS-ID for people without external identifier
+ *
+ * @category    Framework
+ * @package     Opus
+ *
+ * phpcs:disable
+ *
+ * @ORM\Entity(repositoryClass="Opus\Db2\PersonRepository")
+ * @ORM\Table(name="persons",
+ *     indexes={
+ *         @ORM\Index(name="last_name", columns={"last_name"})
+ *     })
+ */
+class Person extends AbstractModel
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="academic_title", type="string", length=255, nullable="true")
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @ORM\Column(name="first_name", type="string", length=255, nullable="true")
+     * @var string
+     */
+    private $firstName;
+
+    /**
+     * @ORM\Column(name="last_name", type="string", length=191, nullable="false")
+     * @var string
+     */
+    private $lastName;
+
+    /**
+     * @ORM\Column(name="date_of_birth", type="opusDate", length=50, nullable="true")
+     * @var Date
+     */
+    private $dateOfBirth;
+
+    /**
+     * @ORM\Column(name="place_of_birth", type="string", length=255, nullable="true")
+     * @var string
+     */
+    private $placeOfBirth;
+
+    /**
+     * @ORM\Column(name="identifier_orcid", type="string", length=50, nullable="true")
+     * @var string
+     */
+    private $identifierOrcid;
+
+    /**
+     * @ORM\Column(name="identifier_gnd", type="string", length=50, nullable="true")
+     * @var string
+     */
+    private $identifierGnd;
+
+    /**
+     * @ORM\Column(name="identifier_misc", type="string", length=50, nullable="true")
+     * @var string
+     */
+    private $identifierMisc;
+
+    /**
+     * @ORM\Column(name="email", type="string", length=191, nullable="true")
+     * @var string
+     */
+    private $email;
+
+    /**
+     * @ORM\Column(name="opus_id", type="integer")
+     * @var string
+     */
+    private $opusId;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @param string $firstName
+     */
+    public function setFirstName($firstName)
+    {
+        $this->firstName = $firstName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    /**
+     * @param string $lastName
+     */
+    public function setLastName($lastName)
+    {
+        $this->lastName = $lastName;
+    }
+
+    /**
+     * @return Date
+     */
+    public function getDateOfBirth()
+    {
+        return $this->dateOfBirth;
+    }
+
+    /**
+     * @param Date $dateOfBirth
+     */
+    public function setDateOfBirth($dateOfBirth)
+    {
+        $this->dateOfBirth = $dateOfBirth;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPlaceOfBirth()
+    {
+        return $this->placeOfBirth;
+    }
+
+    /**
+     * @param string $placeOfBirth
+     */
+    public function setPlaceOfBirth($placeOfBirth)
+    {
+        $this->placeOfBirth = $placeOfBirth;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifierOrcid()
+    {
+        return $this->identifierOrcid;
+    }
+
+    /**
+     * @param string $identifierOrcid
+     */
+    public function setIdentifierOrcid($identifierOrcid)
+    {
+        $this->identifierOrcid = $identifierOrcid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifierGnd()
+    {
+        return $this->identifierGnd;
+    }
+
+    /**
+     * @param string $identifierGnd
+     */
+    public function setIdentifierGnd($identifierGnd)
+    {
+        $this->identifierGnd = $identifierGnd;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifierMisc()
+    {
+        return $this->identifierMisc;
+    }
+
+    /**
+     * @param string $identifierMisc
+     */
+    public function setIdentifierMisc($identifierMisc)
+    {
+        $this->identifierMisc = $identifierMisc;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOpusId()
+    {
+        return $this->opusId;
+    }
+
+    /**
+     * @param string $opusId
+     */
+    public function setOpusId($opusId)
+    {
+        $this->opusId = $opusId;
+    }
+
+    /**
+     * Returns the relevant properties of the class
+     *
+     * @return array
+     */
+    protected static function describe()
+    {
+        return [
+            'Title',
+            'FirstName',
+            'LastName',
+            'DateOfBirth',
+            'PlaceOfBirth',
+            'IdentifierOrcid',
+            'IdentifierGnd',
+            'IdentifierMisc',
+            'Email',
+            'OpusId'
+        ];
+    }
+
+    /**
+     * Plugins to load
+     *
+     * @var array
+     */
+    public function getDefaultPlugins()
+    {
+        return [
+            Model\Plugin\InvalidateDocumentCache::class,
+        ];
+    }
+
+    /**
+     * Get uniform representation of names.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        $firstName = $this->getFirstName();
+
+        if ($firstName !== null) {
+            return $this->getLastName() . ', ' . $firstName;
+        } else {
+            return $this->getLastName();
+        }
+    }
+
+    /**
+     * Returns name.
+     */
+    public function getDisplayName()
+    {
+        return $this->getName();
+    }
+}

--- a/tests/Opus/PersonTest.php
+++ b/tests/Opus/PersonTest.php
@@ -44,7 +44,7 @@ use Opus\Db\TableGateway;
 use Opus\Document;
 use Opus\Model\ModelException;
 use Opus\Model\Xml\Cache;
-use Opus\Person;
+use Opus\Model2\Person;
 use Opus\Title;
 use OpusTest\TestAsset\TestCase;
 
@@ -91,13 +91,13 @@ class PersonTest extends TestCase
 
         // create documents
         for ($i = 0; $i < 10; $i++) {
-            $doc = new Document();
+            $doc = Document::new();
             $doc->store();
             $this->documents[] = $doc;
         }
 
         for ($i = 0; $i < 10; $i++) {
-            $p = new Person();
+            $p = Person::new();
             $p->setFirstName("Dummy-$i")
                 ->setLastName("Empty-$i")
                 ->store();
@@ -106,7 +106,7 @@ class PersonTest extends TestCase
         // add a person as author to every document
         // and add the person to the list of authors
         foreach ($this->documents as $document) {
-            $p = new Person();
+            $p = Person::new();
             $p->setFirstName('Rainer')
                 ->setLastName('Zufall')
                 ->setAcademicTitle('Prof. Dr.')
@@ -161,7 +161,7 @@ class PersonTest extends TestCase
     public function testDeletePerson()
     {
         $docId   = $this->documents[0]->getId();
-        $d       = new Document($docId);
+        $d       = Document::get($docId);
         $persons = $d->getPerson();
         $this->assertTrue(1 === count($persons));
 
@@ -172,13 +172,13 @@ class PersonTest extends TestCase
         $d->setPerson([]);
         $d->store();
 
-        $d = new Document($docId);
+        $d = Document::get($docId);
         $this->assertTrue(0 === count($d->getPerson()));
     }
 
     public function testOnlyLastNameMandatory()
     {
-        $person = new Person();
+        $person = Person::new();
 
         $fields = $person->describe();
 
@@ -195,7 +195,7 @@ class PersonTest extends TestCase
 
     public function testGetNameForLastAndFirstName()
     {
-        $person = new Person();
+        $person = Person::new();
 
         $person->setFirstName('Jane');
         $person->setLastName('Doe');
@@ -205,7 +205,7 @@ class PersonTest extends TestCase
 
     public function testGetNameForLastNameOnly()
     {
-        $person = new Person();
+        $person = Person::new();
 
         $person->setLastName('Doe');
 
@@ -214,7 +214,7 @@ class PersonTest extends TestCase
 
     public function testSetGetIdentifiers()
     {
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Tester');
         $person->setIdentifierOrcid('http://orcid.org/0000-0002-1694-233X');
         $person->setIdentifierGnd('test_gnd_identifier');
@@ -222,7 +222,7 @@ class PersonTest extends TestCase
 
         $personId = $person->store();
 
-        $person = new Person($personId);
+        $person = Person::get($personId);
 
         $this->assertEquals('http://orcid.org/0000-0002-1694-233X', $person->getIdentifierOrcid());
         $this->assertEquals('test_gnd_identifier', $person->getIdentifierGnd());
@@ -234,11 +234,11 @@ class PersonTest extends TestCase
      */
     public function testInvalidateDocumentCache()
     {
-        $person = new Person();
+        $person = Person::new();
         $person->setFirstName('Jane');
         $person->setLastName('Doe');
         $person->store();
-        $doc = new Document();
+        $doc = Document::new();
         $doc->setType("article")
                 ->setServerState('published')
                 ->setPersonAuthor($person);
@@ -318,8 +318,8 @@ class PersonTest extends TestCase
 
         $docId = $this->documents[0]->getId();
 
-        $doc   = new Document($docId);
-        $other = new Person();
+        $doc   = Document::get($docId);
+        $other = Person::new();
         $other->setLastName('Musterfrau');
         $other->setFirstName('Erika');
         $doc->addPersonOther($other);
@@ -353,17 +353,17 @@ class PersonTest extends TestCase
 
     public function testGetAllPersonsSorting()
     {
-        $doc = new Document($this->documents[0]->getId());
+        $doc = Document::get($this->documents[0]->getId());
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Blau');
         $doc->addPersonReferee($person);
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Rot');
         $doc->addPersonReferee($person);
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Grün');
         $doc->addPersonReferee($person);
 
@@ -384,17 +384,17 @@ class PersonTest extends TestCase
      */
     public function testGetAllPersonsSortingWithLeadingSpaces()
     {
-        $doc = new Document($this->documents[0]->getId());
+        $doc = Document::get($this->documents[0]->getId());
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('A');
         $doc->addPersonReferee($person);
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('B');
         $doc->addPersonReferee($person);
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('C');
         $doc->addPersonReferee($person);
 
@@ -420,17 +420,17 @@ class PersonTest extends TestCase
      */
     public function testGetAllPersonsHandlingOfIdentifier()
     {
-        $doc = new Document($this->documents[0]->getId());
+        $doc = Document::get($this->documents[0]->getId());
 
-        $person1 = new Person();
+        $person1 = Person::new();
         $person1->setLastName('Person');
         $doc->addPersonReferee($person1);
 
-        $person2 = new Person();
+        $person2 = Person::new();
         $person2->setLastName('Person');
         $doc->addPersonReferee($person2);
 
-        $person3 = new Person();
+        $person3 = Person::new();
         $person3->setLastName('Person');
         $doc->addPersonReferee($person3);
 
@@ -492,8 +492,8 @@ class PersonTest extends TestCase
         $this->assertArrayHasKey('documents', $role);
         $this->assertEquals(10, $role['documents']);
 
-        $doc    = new Document($this->documents[0]->getId());
-        $person = new Person();
+        $doc    = Document::get($this->documents[0]->getId());
+        $person = Person::new();
         $person->setLastName('Zufall');
         $person->setFirstName('Rainer');
         $doc->addPersonOther($person);
@@ -512,8 +512,8 @@ class PersonTest extends TestCase
         $this->assertInternalType('array', $documents);
         $this->assertCount(10, $documents);
 
-        $doc    = new Document($this->documents[0]->getId());
-        $person = new Person();
+        $doc    = Document::get($this->documents[0]->getId());
+        $person = Person::new();
         $person->setLastName('Zufall');
         $doc->addPersonOther($person);
         $doc->store();
@@ -560,7 +560,7 @@ class PersonTest extends TestCase
 
         $this->assertCount(10, $documents);
 
-        $person2 = new Person();
+        $person2 = Person::new();
         $person2->setLastName('Zufall');
         $this->documents[0]->addPersonAuthor($person2);
         $this->documents[0]->store();
@@ -573,14 +573,14 @@ class PersonTest extends TestCase
 
     public function testGetPersonDocumentsSortedById()
     {
-        $doc1   = new Document();
-        $person = new Person();
+        $doc1   = Document::new();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc1->addPersonAuthor($person);
         $docId1 = $doc1->store();
 
-        $doc2   = new Document();
-        $person = new Person();
+        $doc2   = Document::new();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc2->addPersonAuthor($person);
         $docId2 = $doc2->store();
@@ -608,16 +608,16 @@ class PersonTest extends TestCase
 
     public function testGetPersonDocumentsSortedByType()
     {
-        $doc1 = new Document();
+        $doc1 = Document::new();
         $doc1->setType('article');
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc1->addPersonAuthor($person);
         $docId1 = $doc1->store();
 
-        $doc2 = new Document();
+        $doc2 = Document::new();
         $doc2->setType('dissertation');
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc2->addPersonAuthor($person);
         $docId2 = $doc2->store();
@@ -645,20 +645,20 @@ class PersonTest extends TestCase
 
     public function testGetPersonDocumentsSortedByPublicationDate()
     {
-        $doc1 = new Document();
+        $doc1 = Document::new();
         $date = new Date(new DateTime());
         $doc1->setServerDatePublished($date);
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc1->addPersonAuthor($person);
         $docId1 = $doc1->store();
 
         sleep(2);
 
-        $doc2 = new Document();
+        $doc2 = Document::new();
         $date = new Date(new DateTime());
         $doc2->setServerDatePublished($date);
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc2->addPersonAuthor($person);
         $docId2 = $doc2->store();
@@ -686,20 +686,20 @@ class PersonTest extends TestCase
 
     public function testGetPersonDocumentsSortedByTitle()
     {
-        $doc1  = new Document();
+        $doc1  = Document::new();
         $title = $doc1->addTitleMain();
         $title->setValue('A Title');
         $title->setLanguage('eng');
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc1->addPersonAuthor($person);
         $docId1 = $doc1->store();
 
-        $doc2  = new Document();
+        $doc2  = Document::new();
         $title = $doc2->addTitleMain();
         $title->setValue('B Title');
         $title->setLanguage('eng');
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc2->addPersonAuthor($person);
         $docId2 = $doc2->store();
@@ -728,19 +728,19 @@ class PersonTest extends TestCase
     public function testGetPersonDocumentsSortedByAuthor()
     {
         $this->markTestSkipped('TODO - sorting by author not properly working yet OPUSVIER-3810');
-        $doc1   = new Document();
-        $person = new Person();
+        $doc1   = Document::new();
+        $person = Person::new();
         $person->setLastName('A Person');
         $personLink = $doc1->addPersonAuthor($person);
         $personLink->setSortOrder(0);
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $personLink = $doc1->addPersonAuthor($person);
         $personLink->setSortOrder(1);
         $docId1 = $doc1->store();
 
-        $doc2   = new Document();
-        $person = new Person();
+        $doc2   = Document::new();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc2->addPersonAuthor($person);
         $docId2 = $doc2->store();
@@ -768,20 +768,20 @@ class PersonTest extends TestCase
 
     public function testGetPersonDocumentsByStateSorted()
     {
-        $doc1  = new Document();
+        $doc1  = Document::new();
         $title = $doc1->addTitleMain();
         $title->setValue('A Title');
         $title->setLanguage('eng');
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc1->addPersonAuthor($person);
         $docId1 = $doc1->store();
 
-        $doc2  = new Document();
+        $doc2  = Document::new();
         $title = $doc2->addTitleMain();
         $title->setValue('B Title');
         $title->setLanguage('eng');
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $doc2->addPersonAuthor($person);
         $docId2 = $doc2->store();
@@ -821,7 +821,7 @@ class PersonTest extends TestCase
 
         $doc = $this->documents[0];
 
-        $editor = new Person();
+        $editor = Person::new();
         $editor->setLastName('Zufall');
         $editor->setFirstName('Rainer');
         $doc->addPersonEditor($editor);
@@ -848,7 +848,7 @@ class PersonTest extends TestCase
         $doc = $this->documents[0];
 
         $doc->setServerState('published');
-        $editor = new Person();
+        $editor = Person::new();
         $editor->setLastName('Zufall');
         $editor->setFirstName('Rainer');
         $doc->addPersonEditor($editor);
@@ -876,8 +876,8 @@ class PersonTest extends TestCase
 
     public function testGetAllPersonsWithFilterFirstName()
     {
-        $doc    = new Document($this->documents[0]->getId());
-        $person = new Person();
+        $doc    = Document::get($this->documents[0]->getId());
+        $person = Person::new();
         $person->setLastName('Mustermann');
         $person->setFirstName('Bafala');
         $doc->addPersonOther($person);
@@ -928,12 +928,12 @@ class PersonTest extends TestCase
 
     public function testOpusId()
     {
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Testy');
         $person->setOpusId('12345');
         $personId = $person->store();
 
-        $person = new Person($personId);
+        $person = Person::get($personId);
 
         $this->assertEquals('12345', $person->getOpusId());
         $this->assertEquals('Testy', $person->getLastName());
@@ -964,7 +964,7 @@ class PersonTest extends TestCase
             }
         }
 
-        $person = new Person($personIds[0]);
+        $person = Person::get($personIds[0]);
         $person->setPlaceOfBirth('Hamburg');
         $person->store();
 
@@ -1051,7 +1051,7 @@ class PersonTest extends TestCase
         $this->assertInternalType('array', $personIds);
         $this->assertCount(1, $personIds);
 
-        $person = new Person($personIds[0]);
+        $person = Person::get($personIds[0]);
 
         $this->assertEquals(' Spacey ', $person->getLastName());
     }
@@ -1067,7 +1067,7 @@ class PersonTest extends TestCase
         Person::updateAll($personCrit, $changes);
 
         foreach ($this->authors as $author) {
-            $person = new Person($author->getId());
+            $person = Person::get($author->getId());
 
             $this->assertEquals('bulktest@example.org', $person->getEmail());
         }
@@ -1086,7 +1086,7 @@ class PersonTest extends TestCase
         Person::updateAll($personCrit, $changes, $documents);
 
         foreach ($this->authors as $author) {
-            $person = new Person($author->getId());
+            $person = Person::get($author->getId());
 
             $personDocs = $person->getDocumentsByRole('author');
 
@@ -1110,14 +1110,14 @@ class PersonTest extends TestCase
             'Email' => 'bulktest@example.org',
         ];
 
-        $doc   = new Document();
+        $doc   = Document::new();
         $title = new Title();
         $title->setLanguage('deu');
         $title->setValue('Document with no author');
         $doc->addTitleMain($title);
         $docId = $doc->store();
 
-        $doc = new Document($docId);
+        $doc = Document::get($docId);
 
         $documents = [3, 5, $docId];
 
@@ -1138,7 +1138,7 @@ class PersonTest extends TestCase
 
         //filtered documents were not modified
         foreach ($this->documents as $doc) {
-            $document = new Document($doc->getId()); // don't use old objects - they are not updated
+            $document = Document::get($doc->getId()); // don't use old objects - they are not updated
 
             $dateModified = $document->getServerDateModified();
 
@@ -1211,11 +1211,11 @@ class PersonTest extends TestCase
         Person::updateAll($personCrit, $changes);
 
         for ($index = 0; $index < 4; $index++) {
-            $person = new Person($personIds[$index]);
+            $person = Person::get($personIds[$index]);
             $this->assertEquals('bulktest@example.org', $person->getEmail());
         }
 
-        $person = new Person($personIds[4]);
+        $person = Person::get($personIds[4]);
         $this->assertNull($person->getEmail());
     }
 
@@ -1233,7 +1233,7 @@ class PersonTest extends TestCase
 
         Person::updateAll($personCrit, $changes);
 
-        $person = new Person($personIds[0]);
+        $person = Person::get($personIds[0]);
 
         $this->assertEquals('John', $person->getFirstName());
     }
@@ -1251,7 +1251,7 @@ class PersonTest extends TestCase
         Person::updateAll($personCrit, $changes, $documents);
 
         foreach ($this->authors as $author) {
-            $person = new Person($author->getId());
+            $person = Person::get($author->getId());
 
             $personDocs = $person->getDocumentsByRole('author');
 
@@ -1273,7 +1273,7 @@ class PersonTest extends TestCase
         Person::updateAll($personCrit, $changes, $documents);
 
         foreach ($this->authors as $author) {
-            $person = new Person($author->getId());
+            $person = Person::get($author->getId());
 
             $personDocs = $person->getDocumentsByRole('author');
 
@@ -1313,7 +1313,7 @@ class PersonTest extends TestCase
     {
         $personCrit = ['last_name' => 'Zufall', 'first_name' => 'Rainer'];
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Zufall');
         $person->store(); // not Rainer
 
@@ -1337,7 +1337,7 @@ class PersonTest extends TestCase
         $this->assertCount(4, $personIds);
 
         foreach ($personIds as $personId) {
-            $person = new Person($personId);
+            $person = Person::get($personId);
 
             $documents = $person->getDocumentsByRole('author');
 
@@ -1367,7 +1367,7 @@ class PersonTest extends TestCase
         $this->assertCount(3, $personIds);
 
         foreach ($personIds as $personId) {
-            $person = new Person($personId);
+            $person = Person::get($personId);
 
             $this->assertEquals('Zufall', $person->getLastName());
         }
@@ -1382,7 +1382,7 @@ class PersonTest extends TestCase
         Person::updateAll($personCrit, $changes);
 
         foreach ($this->authors as $author) {
-            $person = new Person($author->getId());
+            $person = Person::get($author->getId());
 
             $this->assertEquals('Plannt', $person->getLastName());
             $this->assertEquals('Volge', $person->getFirstName());
@@ -1449,7 +1449,7 @@ class PersonTest extends TestCase
         $database = $table->getAdapter();
 
         foreach ($persons as $name => $values) {
-            $person = new Person();
+            $person = Person::new();
             $person->setLastName($name);
 
             foreach ($values as $fieldName => $value) {
@@ -1489,7 +1489,7 @@ class PersonTest extends TestCase
             $this->assertArrayHasKey('document_id', $match);
             $personId  = $match['person_id'];
             $docId     = $match['document_id'];
-            $person    = new Person($personId);
+            $person    = Person::get($personId);
             $assocDocs = $person->getDocumentIds();
             $this->assertContains($docId, $assocDocs);
         }
@@ -1520,7 +1520,7 @@ class PersonTest extends TestCase
         $this->assertContains(6, $documentIds);
         $this->assertContains(10, $documentIds);
 
-        $doc = new Document($this->documents[1]->getId());
+        $doc = Document::get($this->documents[1]->getId());
 
         $this->assertEquals(2, $doc->getId());
 
@@ -1540,9 +1540,9 @@ class PersonTest extends TestCase
     {
         $personCrit = ['last_name' => 'Zufall', 'first_name' => 'Rainer'];
 
-        $doc = new Document($this->documents[0]->getId());
+        $doc = Document::get($this->documents[0]->getId());
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Zufall');
         $person->setFirstName('Rainer');
 
@@ -1566,7 +1566,7 @@ class PersonTest extends TestCase
     {
         $personCrit = ['last_name' => 'Zufall', 'first_name' => 'Rainer'];
 
-        $doc = new Document();
+        $doc = Document::new();
         $doc->setType('article');
         $title = new Title();
         $title->setLanguage('eng');
@@ -1590,7 +1590,7 @@ class PersonTest extends TestCase
 
     public function testGetDocumentIds()
     {
-        $person = new Person($this->authors[0]->getId());
+        $person = Person::get($this->authors[0]->getId());
 
         $docIds = $person->getDocumentIds();
 
@@ -1602,8 +1602,8 @@ class PersonTest extends TestCase
 
     public function testGetDocumentIdsUniqueValues()
     {
-        $person = new Person($this->authors[0]->getId());
-        $doc    = new Document($this->documents[0]->getId());
+        $person = Person::get($this->authors[0]->getId());
+        $doc    = Document::get($this->documents[0]->getId());
 
         $doc->addPersonAdvisor($person);
         $doc->store();
@@ -1618,7 +1618,7 @@ class PersonTest extends TestCase
 
     public function testGetDocumentIdsForRole()
     {
-        $person = new Person($this->authors[0]->getId());
+        $person = Person::get($this->authors[0]->getId());
 
         $docIds = $person->getDocumentIds('author');
 
@@ -1680,7 +1680,7 @@ class PersonTest extends TestCase
 
     public function testGetDocumentsOnePersonTwoDocuments()
     {
-        $doc = new Document($this->documents[1]->getId());
+        $doc = Document::get($this->documents[1]->getId());
         $doc->addPersonSubmitter($this->authors[0]);
         $docId = $doc->store();
 
@@ -1701,8 +1701,8 @@ class PersonTest extends TestCase
 
     public function testGetDocumentsTwoPersonsOneDocument()
     {
-        $doc    = new Document($this->documents[0]->getId());
-        $person = new Person();
+        $doc    = Document::get($this->documents[0]->getId());
+        $person = Person::new();
         $person->setLastName('Tester');
         $plink = $doc->addPersonSubmitter($person);
         $doc->store();
@@ -1776,12 +1776,12 @@ class PersonTest extends TestCase
 
     public function testStoreValuesAreTrimmed()
     {
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName(' Zufall ');
         $person->setFirstName(' Rainer ');
         $personId = $person->store();
 
-        $person = new Person($personId);
+        $person = Person::get($personId);
 
         $this->assertEquals('Zufall', $person->getLastName());
         $this->assertEquals('Rainer', $person->getFirstName());
@@ -1794,11 +1794,11 @@ class PersonTest extends TestCase
     {
         $this->markTestIncomplete('TODO not sure what/how to test');
 
-        $doc = new Document();
+        $doc = Document::new();
         $doc->setServerState('published');
         $doc->setType('article');
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Tester');
 
         $doc->addPersonAuthor($person);
@@ -1807,29 +1807,29 @@ class PersonTest extends TestCase
 
         $person->delete();
 
-        // $doc = new Document($docId);
+        // $doc = Document::get($docId);
 
         $doc->delete();
 
         $this->setExpectedException(ModelException::class, 'No Opus\Db\Documents with id');
-        new Document($docId);
+        Document::get($docId);
     }
 
     public function testSortOrderDefault()
     {
-        $doc = new Document();
+        $doc = Document::new();
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Person1');
         $doc->addPersonAuthor($person);
 
-        $person = new Person();
+        $person = Person::new();
         $person->setLastName('Person2');
         $doc->addPersonAuthor($person);
 
         $docId = $doc->store();
 
-        $doc = new Document($docId);
+        $doc = Document::get($docId);
 
         $authors = $doc->getPersonAuthor();
 
@@ -1844,8 +1844,8 @@ class PersonTest extends TestCase
 
     public function testMatchesPersonObjects()
     {
-        $person1 = new Person();
-        $person2 = new Person();
+        $person1 = Person::new();
+        $person2 = Person::new();
 
         // Test LastName matching
 
@@ -1922,7 +1922,7 @@ class PersonTest extends TestCase
 
     public function testToArray()
     {
-        $person = new Person();
+        $person = Person::new();
         $person->setAcademicTitle('Prof.');
         $person->setFirstName('Thomas');
         $person->setLastName('Mueller');
@@ -1986,7 +1986,7 @@ class PersonTest extends TestCase
 
     public function testUpdateFromArray()
     {
-        $person = new Person();
+        $person = Person::new();
 
         $person->updateFromArray([
             'AcademicTitle'   => 'Prof.',
@@ -2015,7 +2015,7 @@ class PersonTest extends TestCase
 
     public function testGetModelType()
     {
-        $person = new Person();
+        $person = Person::new();
         $this->assertEquals('person', $person->getModelType());
     }
 }

--- a/tests/Opus/PersonTest.php
+++ b/tests/Opus/PersonTest.php
@@ -44,7 +44,7 @@ use Opus\Db\TableGateway;
 use Opus\Document;
 use Opus\Model\ModelException;
 use Opus\Model\Xml\Cache;
-use Opus\Model2\Person;
+use Opus\Person;
 use Opus\Title;
 use OpusTest\TestAsset\TestCase;
 
@@ -97,7 +97,7 @@ class PersonTest extends TestCase
         }
 
         for ($i = 0; $i < 10; $i++) {
-            $p = Person::new();
+            $p = new Person();
             $p->setFirstName("Dummy-$i")
                 ->setLastName("Empty-$i")
                 ->store();
@@ -106,7 +106,7 @@ class PersonTest extends TestCase
         // add a person as author to every document
         // and add the person to the list of authors
         foreach ($this->documents as $document) {
-            $p = Person::new();
+            $p = new Person();
             $p->setFirstName('Rainer')
                 ->setLastName('Zufall')
                 ->setAcademicTitle('Prof. Dr.')
@@ -127,6 +127,7 @@ class PersonTest extends TestCase
         // TODO: der Tabelle link_persons_documents.
         //
         // TODO: Die ID der Person erhält man mit getLinkedModelId()
+        // TODO: Die ID der Person
 
         foreach ($this->authors as $author) {
             $docs = $author->getDocumentsByRole('author');


### PR DESCRIPTION
Person-Model auf Doctrine-ORM umstellen.
Implementierung der Verwaltungsfunktionen aus Opus\Person lösen und in einer eignen Repository-Klasse auf Doctrin umstellen.